### PR TITLE
refactor: comprehensive code quality improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.14] - 2026-02-21
+
+### Fixed
+
+- Fix stale accessory handler leak when device IP is rediscovered - old handler is now destroyed before recreating
+- Fix linked service direction in HomeKit - secondary services (sensors, switches) are now correctly linked to the primary Air Purifier service
+- Fix duplicate connect event emission causing double state sync on reconnection
+- Fix double resolve in mDNS discovery when timeout and early stop fire simultaneously
+- Fix unhandled promise rejection when `commandError` event has no listeners
+- Fix NightModeService returning `undefined` when device state is not yet set
+- Fix infinite MQTT retry recursion in UI server when `_retried` flag was set but never checked
+- Fix stale cached accessories not removed from internal map after unregistration
+- Fix `pollingInterval` config option not being applied to device polling
+- Fix global `enableFilterStatus` and `enableHumidifier` config options not propagated to devices
+- Fix silent credential decryption failures - now logs a warning instead of silently returning empty string
+- Fix raw device state leaked to frontend in UI server device state response
+- Fix README config option names (`pollInterval` -> `pollingInterval`, `enableFilter` -> `enableFilterStatus`)
+
+### Added
+
+- Support for TP11 (Purifier Cool) and HP11 (Purifier Hot+Cool) models in supported devices table
+- Support for both v2 and v3 Dyson Cloud API field name formats in UI server for forward compatibility
+- Pending auth timeout (10 minutes) in UI server to clear stored credentials from memory
+- `HEATING_TOLERANCE_CELSIUS` constant replacing magic number in HeaterCooler temperature comparison
+
+### Changed
+
+- Model name in HomeKit AccessoryInformation now uses the device catalog (e.g., "Dyson Pure Cool Tower (TP04)") instead of a hardcoded map
+- Timer handles (sleep, rate limit, mDNS) now use `.unref()` for clean Node.js shutdown
+- Removed unused `EveHomeKitTypes` import and related properties from platform
+- Removed unused device options from `DeviceOptions` interface (`enableAutoModeWhenActivating`, `enableOscillationWhenActivating`, `enableNightModeWhenActivating`, etc.)
+- Added PH03 product type `358J` to config schema (was missing alongside existing `358H`)
+
 ## [1.0.13] - 2026-01-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix device not turning off - command batching could overwrite the OFF command with a concurrent mode change (e.g. AUTO), preventing the device from turning off
+- Restore TP06 (Pure Cool Cryptomic) to supported devices - was incorrectly removed during earlier refactoring (shares product type `438` with TP04)
 - Fix stale accessory handler leak when device IP is rediscovered - old handler is now destroyed before recreating
 - Fix linked service direction in HomeKit - secondary services (sensors, switches) are now correctly linked to the primary Air Purifier service
 - Fix duplicate connect event emission causing double state sync on reconnection

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | Series | Models | Features |
 |--------|--------|----------|
 | **Pure Cool Link** | TP02, DP01 | Fan, Air Quality, Temp, Humidity |
-| **Pure Cool** | TP04, TP07, DP04 | Fan, Air Quality, Temp, Humidity, Jet Focus |
+| **Pure Cool** | TP04, TP06, TP07, DP04 | Fan, Air Quality, Temp, Humidity, Jet Focus |
 | **Pure Cool Formaldehyde** | TP09 | Fan, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Cool** | TP11 | Fan, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Pure Hot+Cool Link** | HP02 | Fan, Heating, Air Quality, Temp, Humidity, Jet Focus |

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@
 | Series | Models | Features |
 |--------|--------|----------|
 | **Pure Cool Link** | TP02, DP01 | Fan, Air Quality, Temp, Humidity |
-| **Pure Cool** | TP04, TP06, TP07, DP04 | Fan, Air Quality, Temp, Humidity, Jet Focus |
+| **Pure Cool** | TP04, TP07, DP04 | Fan, Air Quality, Temp, Humidity, Jet Focus |
 | **Pure Cool Formaldehyde** | TP09 | Fan, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
+| **Purifier Cool** | TP11 | Fan, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Pure Hot+Cool Link** | HP02 | Fan, Heating, Air Quality, Temp, Humidity, Jet Focus |
 | **Pure Hot+Cool** | HP04, HP06, HP07 | Fan, Heating, Air Quality, Temp, Humidity, Jet Focus |
 | **Pure Hot+Cool Formaldehyde** | HP09 | Fan, Heating, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
+| **Purifier Hot+Cool** | HP11 | Fan, Heating, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Humidify+Cool** | PH01, PH02, PH03 | Fan, Humidifier, Air Quality, Temp, Humidity, Jet Focus |
 | **Purifier Humidify+Cool Formaldehyde** | PH04 | Fan, Humidifier, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Big+Quiet** | BP02, BP03, BP04, BP06 | Fan, Air Quality (incl. NO2), Temp, Humidity |
@@ -93,7 +95,7 @@ If you prefer not to use your Dyson account, you can configure devices manually:
 |--------|------|---------|-------------|
 | `countryCode` | string | `US` | Account country code (US, GB, DE, etc.) |
 | `discoveryTimeout` | number | `30` | mDNS discovery timeout in seconds |
-| `pollInterval` | number | `60` | State polling interval in seconds |
+| `pollingInterval` | number | `60` | State polling interval in seconds (10-300) |
 
 #### Feature Toggles
 
@@ -107,7 +109,7 @@ If you prefer not to use your Dyson account, you can configure devices manually:
 | `enableJetFocus` | boolean | `true` | Show jet focus switch |
 | `enableHeater` | boolean | `true` | Show thermostat for HP models |
 | `enableHumidifier` | boolean | `true` | Show humidifier for PH models |
-| `enableFilter` | boolean | `true` | Show filter status |
+| `enableFilterStatus` | boolean | `false` | Show filter life remaining indicator |
 
 #### Per-Device Options
 
@@ -116,9 +118,8 @@ If you prefer not to use your Dyson account, you can configure devices manually:
 | `temperatureOffset` | number | `0` | Temperature calibration offset (°C) |
 | `humidityOffset` | number | `0` | Humidity calibration offset (%) |
 | `fullRangeHumidity` | boolean | `false` | Enable 0-100% humidity range (default: 30-70%) |
-| `enableAutoModeWhenActivating` | boolean | `false` | Auto-enable auto mode on power on |
-| `enableOscillationWhenActivating` | boolean | `false` | Auto-enable oscillation on power on |
-| `enableNightModeWhenActivating` | boolean | `false` | Auto-enable night mode on power on |
+| `heatingServiceType` | string | `thermostat` | Heating service type: `thermostat`, `heater-cooler`, or `both` |
+| `useFahrenheit` | boolean | `false` | Display temperature in Fahrenheit in logs |
 
 ## HomeKit Controls
 
@@ -198,7 +199,7 @@ To use the device as a fan without heating, simply turn off the heater and contr
 ### Sensors Not Updating
 
 1. Ensure continuous monitoring is enabled on the device
-2. Check `pollInterval` isn't set too high
+2. Check `pollingInterval` isn't set too high
 3. Some sensors take time to initialize after power-on
 
 ### Temperature/Humidity Readings Inaccurate

--- a/config.schema.json
+++ b/config.schema.json
@@ -96,6 +96,11 @@
               "type": "string",
               "description": "MQTT password for local device connection (obtained from Dyson cloud)"
             },
+            "credentials": {
+              "title": "Credentials (Legacy)",
+              "type": "string",
+              "description": "Legacy credentials field. Use 'localCredentials' for new configurations."
+            },
             "ipAddress": {
               "title": "IP Address (Optional)",
               "type": "string",
@@ -208,7 +213,7 @@
               "description": "Show jet focus (diffuse/focused airflow) switch in HomeKit"
             }
           },
-          "required": ["serial", "productType", "localCredentials"]
+          "required": ["serial", "productType"]
         }
       },
       "isSingleAccessoryModeEnabled": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -83,6 +83,7 @@
                 { "title": "PH01 - Purifier Humidify+Cool", "enum": ["358"] },
                 { "title": "PH02 - Purifier Humidify+Cool", "enum": ["520E"] },
                 { "title": "PH03 - Purifier Humidify+Cool", "enum": ["358H"] },
+                { "title": "PH03 - Purifier Humidify+Cool", "enum": ["358J"] },
                 { "title": "PH03/PH04 - Purifier Humidify+Cool Formaldehyde", "enum": ["358E"] },
                 { "title": "PH04 - Purifier Humidify+Cool Formaldehyde", "enum": ["520F"] },
                 { "title": "BP02 - Purifier Big+Quiet", "enum": ["664"] },

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -129,7 +129,8 @@ function decryptCredentials(encryptedCredentials) {
 
     const data = JSON.parse(decrypted.toString('utf8'));
     return data.apPasswordHash || '';
-  } catch {
+  } catch (error) {
+    console.warn('[DysonUI] Failed to decrypt device credentials:', error?.message || 'unknown error');
     return '';
   }
 }
@@ -146,6 +147,18 @@ async function handleAuthenticate(ctx, payload) {
   }
 
   ctx.pendingAuth = { email, password, countryCode };
+
+  // Clear any existing timeout and set a new one to avoid holding credentials in memory
+  if (ctx._pendingAuthTimer) clearTimeout(ctx._pendingAuthTimer);
+  ctx._pendingAuthTimer = setTimeout(() => {
+    if (ctx.pendingAuth) {
+      console.log('[DysonUI] Clearing stale pending auth (timeout)');
+      ctx.pendingAuth = null;
+      ctx.challengeId = null;
+    }
+    ctx._pendingAuthTimer = null;
+  }, PENDING_AUTH_TIMEOUT);
+
   console.log(`[DysonUI] Auth: country: ${countryCode}`);
 
   try {
@@ -213,6 +226,7 @@ async function handleVerifyOtp(ctx, payload) {
     console.log('[DysonUI] Verify success');
     ctx.pendingAuth = null;
     ctx.challengeId = null;
+    if (ctx._pendingAuthTimer) { clearTimeout(ctx._pendingAuthTimer); ctx._pendingAuthTimer = null; }
 
     return { success: true, token: response.token };
   } catch (error) {
@@ -224,6 +238,7 @@ async function handleVerifyOtp(ctx, payload) {
 
     ctx.pendingAuth = null;
     ctx.challengeId = null;
+    if (ctx._pendingAuthTimer) { clearTimeout(ctx._pendingAuthTimer); ctx._pendingAuthTimer = null; }
     throw error;
   }
 }
@@ -247,16 +262,28 @@ async function handleGetDevices(payload) {
     console.log(`[DysonUI] Found ${manifest?.length || 0} devices`);
 
     const devices = (manifest || []).map((d) => {
-      const features = getDeviceFeatures(d.ProductType);
+      // Support both v2 field names (Serial, ProductType, etc.) and
+      // v3 field names (serialNumber, type, etc.) for API compatibility
+      const serial = d.Serial || d.serialNumber;
+      const productType = d.ProductType || d.type;
+      const name = d.Name || d.name || d.productName;
+      const version = d.Version || '';
+      const autoUpdate = d.AutoUpdate ?? d.connectedConfiguration?.firmware?.autoUpdate ?? false;
+      const newVersionAvailable = d.NewVersionAvailable ?? false;
+
+      // Credentials: v2 uses LocalCredentials, v3 uses connectedConfiguration.mqtt.localBrokerCredentials
+      const rawCredentials = d.LocalCredentials || d.connectedConfiguration?.mqtt?.localBrokerCredentials || '';
+
+      const features = getDeviceFeatures(productType);
       return {
-        serial: d.Serial,
-        name: d.Name,
-        productType: d.ProductType,
-        productName: productTypes[d.ProductType] || `Unknown (${d.ProductType})`,
-        version: d.Version,
-        localCredentials: decryptCredentials(d.LocalCredentials),
-        autoUpdate: d.AutoUpdate,
-        newVersionAvailable: d.NewVersionAvailable,
+        serial,
+        name,
+        productType,
+        productName: productTypes[productType] || `Unknown (${productType})`,
+        version,
+        localCredentials: rawCredentials ? decryptCredentials(rawCredentials) : '',
+        autoUpdate,
+        newVersionAvailable,
         // Expose device capabilities from catalog
         hasHeating: features.heating,
         hasHumidifier: features.humidifier,
@@ -390,7 +417,6 @@ async function handleGetDeviceState(ctx, payload) {
     return {
       success: true,
       continuousMonitoring,
-      rawState: state['product-state'],
       discoveredIp: discovered ? ip : undefined,
     };
   } catch (error) {
@@ -401,8 +427,8 @@ async function handleGetDeviceState(ctx, payload) {
       // Ignore disconnect errors
     }
 
-    // If connection failed with cached IP, try mDNS discovery
-    if (ipAddress && !discovered) {
+    // If connection failed with cached IP, try mDNS discovery (but only once)
+    if (ipAddress && !discovered && !payload._retried) {
       console.log(`[DysonUI] Cached IP failed, trying mDNS discovery...`);
       const freshResult = await getDeviceIp(ctx, serial, null);
       if (freshResult.ip && freshResult.ip !== ipAddress) {
@@ -478,8 +504,8 @@ async function handleSetContinuousMonitoring(ctx, payload) {
       // Ignore disconnect errors
     }
 
-    // If connection failed with cached IP, try mDNS discovery
-    if (ipAddress && !discovered) {
+    // If connection failed with cached IP, try mDNS discovery (but only once)
+    if (ipAddress && !discovered && !payload._retried) {
       console.log(`[DysonUI] Cached IP failed, trying mDNS discovery...`);
       const freshResult = await getDeviceIp(ctx, serial, null);
       if (freshResult.ip && freshResult.ip !== ipAddress) {
@@ -496,12 +522,16 @@ async function handleSetContinuousMonitoring(ctx, payload) {
 // Server
 // =============================================================================
 
+/** Timeout to clear pending auth (10 minutes) */
+const PENDING_AUTH_TIMEOUT = 10 * 60 * 1000;
+
 class DysonUiServer extends HomebridgePluginUiServer {
   constructor() {
     super();
 
     this.challengeId = null;
     this.pendingAuth = null;
+    this._pendingAuthTimer = null;
 
     this.onRequest('/authenticate', (p) => handleAuthenticate(this, p));
     this.onRequest('/verify-otp', (p) => handleVerifyOtp(this, p));

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -13,7 +13,6 @@
 
 import { HomebridgePluginUiServer, RequestError } from '@homebridge/plugin-ui-utils';
 import { createDecipheriv } from 'node:crypto';
-import { execSync } from 'node:child_process';
 
 import { getProductTypeDisplayNames, getDeviceFeatures, getHeatingDevices } from '../dist/config/index.js';
 import { DysonMqttClient } from '../dist/protocol/mqttClient.js';
@@ -47,94 +46,72 @@ const DEFAULT_HEADERS = {
 };
 
 // =============================================================================
-// HTTP Client (curl-based)
+// HTTP Client (native fetch)
 // =============================================================================
 
-function dysonRequest(endpoint, options = {}) {
+async function dysonRequest(endpoint, options = {}) {
   const url = `${DYSON_API_BASE_URL}${endpoint}`;
   const method = options.method || 'GET';
 
   console.log(`[DysonUI] ${method} ${endpoint}`);
 
-  const curlArgs = buildCurlCommand(url, method, options);
-  const shellCmd = escapeForShell(curlArgs);
-
-  return executeCurl(shellCmd, options.body);
-}
-
-function buildCurlCommand(url, method, options) {
-  const args = ['curl', '-s', '-X', method, '-H', 'Content-Type: application/json'];
-
-  // Add default headers
-  for (const [key, value] of Object.entries(DEFAULT_HEADERS)) {
-    args.push('-H', `${key}: ${value}`);
-  }
-
-  // Add custom headers
-  if (options.headers) {
-    for (const [key, value] of Object.entries(options.headers)) {
-      args.push('-H', `${key}: ${value}`);
-    }
-  }
-
-  // Add body
-  if (options.body) {
-    args.push('-d', options.body);
-  }
-
-  args.push(url);
-  return args;
-}
-
-function escapeForShell(args) {
-  return args.map((arg) => {
-    if (arg.startsWith('-')) return arg;
-    return `'${arg.replace(/'/g, "'\\''")}'`;
-  }).join(' ');
-}
-
-function executeCurl(shellCmd, body) {
-  if (body) {
-    console.log(`[DysonUI] Body: ${body}`);
-  }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
 
   try {
-    const output = execSync(shellCmd, {
-      encoding: 'utf8',
-      timeout: REQUEST_TIMEOUT,
-      maxBuffer: 1024 * 1024,
-    });
+    const headers = {
+      'Content-Type': 'application/json',
+      ...DEFAULT_HEADERS,
+      ...(options.headers || {}),
+    };
 
-    console.log(`[DysonUI] Response: ${output.substring(0, 200)}`);
+    const fetchOptions = {
+      method,
+      headers,
+      signal: controller.signal,
+    };
 
-    if (!output?.trim()) return null;
+    if (options.body) {
+      fetchOptions.body = options.body;
+    }
 
-    const data = JSON.parse(output);
+    const response = await fetch(url, fetchOptions);
+
+    clearTimeout(timeoutId);
+
+    const text = await response.text();
+    console.log(`[DysonUI] Response status: ${response.status}`);
+
+    if (!text?.trim()) return null;
+
+    const data = JSON.parse(text);
 
     if (data.Message?.includes('Unable to authenticate')) {
       throw new RequestError(data.Message, { status: 401 });
     }
 
+    if (!response.ok) {
+      throw new RequestError(data.Message || `HTTP ${response.status}`, { status: response.status });
+    }
+
     return data;
   } catch (error) {
-    handleCurlError(error);
+    clearTimeout(timeoutId);
+
+    if (error instanceof RequestError) throw error;
+
+    if (error.name === 'AbortError') {
+      throw new RequestError('Request timed out', { status: 408 });
+    }
+
+    if (error.message?.includes('JSON')) {
+      console.error('[DysonUI] JSON parse error:', error.message);
+      throw new RequestError('Invalid response from Dyson API', { status: 500 });
+    }
+
+    console.error('[DysonUI] Fetch error:', error.message);
+    throw new RequestError(`Network error: ${error.message}`, { status: 500 });
   }
-}
-
-function handleCurlError(error) {
-  if (error instanceof RequestError) throw error;
-
-  if (error.message?.includes('JSON')) {
-    console.error('[DysonUI] JSON parse error:', error.message);
-    throw new RequestError('Invalid response from Dyson API', { status: 500 });
-  }
-
-  if (error.killed) {
-    throw new RequestError('Request timed out', { status: 408 });
-  }
-
-  console.error('[DysonUI] Curl error:', error.message);
-  throw new RequestError(`Network error: ${error.message}`, { status: 500 });
 }
 
 // =============================================================================
@@ -169,7 +146,7 @@ async function handleAuthenticate(ctx, payload) {
   }
 
   ctx.pendingAuth = { email, password, countryCode };
-  console.log(`[DysonUI] Auth: ${email}, country: ${countryCode}`);
+  console.log(`[DysonUI] Auth: country: ${countryCode}`);
 
   try {
     // Step 1: Check user status
@@ -328,7 +305,7 @@ const MDNS_TIMEOUT = 5000;
 async function getDeviceIp(ctx, serial, configIp) {
   // Try config IP first if provided
   if (configIp) {
-    console.log(`[DysonUI] Using cached IP ${configIp} for ${serial}`);
+    console.log(`[DysonUI] Using cached IP for ${serial}`);
     return { ip: configIp, discovered: false };
   }
 
@@ -371,7 +348,7 @@ async function handleGetDeviceState(ctx, payload) {
     throw new RequestError(`Device ${serial} not found on network`, { status: 404 });
   }
 
-  console.log(`[DysonUI] Connecting to ${serial} at ${ip}`);
+  console.log(`[DysonUI] Connecting to ${serial}`);
 
   const client = new DysonMqttClient({
     host: ip,
@@ -426,7 +403,7 @@ async function handleGetDeviceState(ctx, payload) {
 
     // If connection failed with cached IP, try mDNS discovery
     if (ipAddress && !discovered) {
-      console.log(`[DysonUI] Cached IP ${ipAddress} failed, trying mDNS discovery...`);
+      console.log(`[DysonUI] Cached IP failed, trying mDNS discovery...`);
       const freshResult = await getDeviceIp(ctx, serial, null);
       if (freshResult.ip && freshResult.ip !== ipAddress) {
         // Retry with freshly discovered IP
@@ -503,7 +480,7 @@ async function handleSetContinuousMonitoring(ctx, payload) {
 
     // If connection failed with cached IP, try mDNS discovery
     if (ipAddress && !discovered) {
-      console.log(`[DysonUI] Cached IP ${ipAddress} failed, trying mDNS discovery...`);
+      console.log(`[DysonUI] Cached IP failed, trying mDNS discovery...`);
       const freshResult = await getDeviceIp(ctx, serial, null);
       if (freshResult.ip && freshResult.ip !== ipAddress) {
         // Retry with freshly discovered IP

--- a/nodemon.json
+++ b/nodemon.json
@@ -4,7 +4,7 @@
   ],
   "ext": "ts",
   "ignore": [],
-  "exec": "tsc && homebridge -U ./test/hbConfig -D",
+  "exec": "tsc && npx homebridge-config-ui-x run -U ./test/hbConfig -D",
   "signal": "SIGTERM",
   "env": {
     "NODE_OPTIONS": "--trace-warnings"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@mp-consulting/homebridge-dyson-pure-cool",
-  "version": "1.0.8",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mp-consulting/homebridge-dyson-pure-cool",
-      "version": "1.0.8",
-      "license": "Apache-2.0",
+      "version": "1.0.13",
+      "license": "MIT",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^1.0.3",
         "bonjour-service": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mp-consulting/homebridge-dyson-pure-cool",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mp-consulting/homebridge-dyson-pure-cool",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^1.0.3",
@@ -20,6 +20,7 @@
         "@types/node": "^24.10.1",
         "eslint": "^9.39.1",
         "homebridge": "^2.0.0-beta.55",
+        "homebridge-config-ui-x": "^5.15.0",
         "jest": "^30.2.0",
         "nodemon": "^3.1.11",
         "rimraf": "^6.1.0",
@@ -583,6 +584,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
+      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -774,6 +786,381 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.1.tgz",
+      "integrity": "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fastify/cors": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
+      "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/formbody": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/formbody/-/formbody-8.0.2.tgz",
+      "integrity": "sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.4.0.tgz",
+      "integrity": "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz",
+      "integrity": "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.0.0.tgz",
+      "integrity": "sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^1.0.1",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/minimatch": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@homebridge/ciao": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
@@ -806,6 +1193,35 @@
       },
       "bin": {
         "dbus2js": "bin/dbus2js.js"
+      }
+    },
+    "node_modules/@homebridge/hap-client": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-client/-/hap-client-3.3.0.tgz",
+      "integrity": "sha512-Vi2mo4f/T+KNsjbDX4y8PeLem0Lw/hJj7UweLaecLyUlzI14VOnY2HAADk9DP1/V3e6aX4gz+p8CI2BRG8G9TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.13.5",
+        "bonjour-service": "1.3.0",
+        "decamelize": "5.0.1",
+        "inflection": "3.0.2",
+        "source-map-support": "0.5.21"
+      }
+    },
+    "node_modules/@homebridge/node-pty-prebuilt-multiarch": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@homebridge/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.13.1.tgz",
+      "integrity": "sha512-ccQ60nMcbEGrQh0U9E6x0ajW9qJNeazpcM/9CH6J8leyNtJgb+gu24WTBAfBUVeO486ZhscnaxLEITI2HXwhow==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "prebuild-install": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=18.0.0 <25.0.0"
       }
     },
     "node_modules/@homebridge/plugin-ui-utils": {
@@ -905,6 +1321,19 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1564,6 +1993,26 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@matter/general": {
       "version": "0.16.0-alpha.0-20251115-d89e62680",
       "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.16.0-alpha.0-20251115-d89e62680.tgz",
@@ -1654,6 +2103,13 @@
         "@matter/model": "0.16.0-alpha.0-20251115-d89e62680"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1665,6 +2121,253 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
+      "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^7.0.0"
+      }
+    },
+    "node_modules/@nestjs/common": {
+      "version": "11.1.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.13.tgz",
+      "integrity": "sha512-ieqWtipT+VlyDWLz5Rvz0f3E5rXcVAnaAi+D53DEHLjc1kmFxCgZ62qVfTX2vwkywwqNkTNXvBgGR72hYqV//Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "21.3.0",
+        "iterare": "1.2.1",
+        "load-esm": "1.0.3",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "class-transformer": ">=0.4.1",
+        "class-validator": ">=0.13.2",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/core": {
+      "version": "11.1.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.13.tgz",
+      "integrity": "sha512-Tq9EIKiC30EBL8hLK93tNqaToy0hzbuVGYt29V8NhkVJUsDzlmiVf6c3hSPtzx2krIUVbTgQ2KFeaxr72rEyzQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/opencollective": "0.4.1",
+        "fast-safe-stringify": "2.1.1",
+        "iterare": "1.2.1",
+        "path-to-regexp": "8.3.0",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/jwt": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz",
+      "integrity": "sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "9.0.10",
+        "jsonwebtoken": "9.0.3"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/passport": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
+      "integrity": "sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "passport": "^0.5.0 || ^0.6.0 || ^0.7.0"
+      }
+    },
+    "node_modules/@nestjs/platform-fastify": {
+      "version": "11.1.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-11.1.13.tgz",
+      "integrity": "sha512-08VkZt5SVRtRyuEzRxY5KzrtsTSiqTSQlySUI8GUVhINHV/iziB6GKOWJc3upTmxvYG/5LSmDO4hv8kDnsWNCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/cors": "11.2.0",
+        "@fastify/formbody": "8.0.2",
+        "fast-querystring": "1.1.2",
+        "fastify": "5.7.4",
+        "fastify-plugin": "5.1.0",
+        "find-my-way": "9.4.0",
+        "light-my-request": "6.6.0",
+        "path-to-regexp": "8.3.0",
+        "reusify": "1.1.0",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@fastify/view": "^10.0.0 || ^11.0.0",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "@fastify/view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.13.tgz",
+      "integrity": "sha512-04Rh16IopZzHRXt0ZjFASqt9oNFV/0m0NsYe4kVOSaTEoef3cH7cTFpNpHsfNHcc4QpYL963XE8SvIRcZs5L8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.3",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.23",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.31.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.1.13",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.13.tgz",
+      "integrity": "sha512-8r8EadqBkrTYtH2uog42HfIb5fcP5a3iXymH/ityd9bO/gDson5Q1qbtCQRjuU++6NY12YYteKRu4eP/iErbLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
       }
     },
     "node_modules/@noble/curves": {
@@ -1734,6 +2437,92 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nuxt/opencollective": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
+      "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      },
+      "bin": {
+        "opencollective": "bin/opencollective.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0",
+        "npm": ">=5.10.0"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.3.0.tgz",
+      "integrity": "sha512-pnQDOuCmFVeF/XnboJq9TOJgLoo2idNPJKMymOF8vGqJJ+ReKRYM9bUGjNPRWC0tHjMwu1TXbnzyBp494JgRag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@otplib/hotp": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@otplib/hotp/-/hotp-13.3.0.tgz",
+      "integrity": "sha512-XJMZGz2bg4QJwK7ulvl1GUI2VMn/flaIk/E/BTKAejHsX2kUtPF1bRhlZ2+elq8uU5Fs9Z9FHcQK2CPZNQbbUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.3.0",
+        "@otplib/uri": "13.3.0"
+      }
+    },
+    "node_modules/@otplib/plugin-base32-scure": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-base32-scure/-/plugin-base32-scure-13.3.0.tgz",
+      "integrity": "sha512-/jYbL5S6GB0Ie3XGEWtLIr9s5ZICl/BfmNL7+8/W7usZaUU4GiyLd2S+JGsNCslPyqNekSudD864nDAvRI0s8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.3.0",
+        "@scure/base": "^2.0.0"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto-noble/-/plugin-crypto-noble-13.3.0.tgz",
+      "integrity": "sha512-wmV+jBVncepgwv99G7Plrdzd0tHfbpXk2U+OD7MO7DzpDqOYEgOPi+IIneksJSTL8QvWdfi+uQEuhnER4fKouA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "@otplib/core": "13.3.0"
+      }
+    },
+    "node_modules/@otplib/totp": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@otplib/totp/-/totp-13.3.0.tgz",
+      "integrity": "sha512-XfjGNoN8d9S3Ove2j7AwkVV7+QDFsV7Lm7YwSiezNaHffkWtJ60aJYpmf+01dARdPST71U2ptueMsRJso4sq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.3.0",
+        "@otplib/hotp": "13.3.0",
+        "@otplib/uri": "13.3.0"
+      }
+    },
+    "node_modules/@otplib/uri": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@otplib/uri/-/uri-13.3.0.tgz",
+      "integrity": "sha512-3oh6nBXy+cm3UX9cxEAGZiDrfxHU2gfelYFV+XNCx+8dq39VaQVymwlU2yjPZiMAi/3agaUeEftf2RwM5F+Cyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.3.0"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1756,6 +2545,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1784,6 +2591,38 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -1869,6 +2708,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1921,6 +2770,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
@@ -1943,6 +2810,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2518,6 +3392,27 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2570,6 +3465,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2666,6 +3603,23 @@
       "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2679,6 +3633,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2807,6 +3794,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
@@ -2816,6 +3813,13 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bash-color": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
+      "integrity": "sha512-ZNB4525U7BxT6v9C8LEtywyCgB4Pjnm7/bh+ru/Z9Ecxvg3fDjaJ6z305z9a61orQdbB1zqYHh5JbUqx4s4K0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2841,6 +3845,13 @@
         "inherits": "^2.0.4",
         "readable-stream": "^4.2.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bonjour-hap": {
       "version": "3.9.1",
@@ -2980,6 +3991,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3140,6 +4158,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -3162,6 +4190,54 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
+      "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.20"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -3241,6 +4317,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3278,6 +4364,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.2",
@@ -3331,6 +4430,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3338,12 +4461,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3360,6 +4535,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3375,6 +4557,35 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -3422,6 +4633,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3473,6 +4694,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -3528,12 +4789,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -3561,6 +4882,79 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
+      "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -3622,6 +5016,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3631,6 +5041,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3888,6 +5305,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
@@ -3905,6 +5332,13 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3949,10 +5383,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz",
+      "integrity": "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3978,6 +5478,74 @@
       "engines": {
         "node": ">=18.2.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
+      "integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4012,6 +5580,25 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
+      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4023,6 +5610,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.4.0.tgz",
+      "integrity": "sha512-5Ye4vHsypZRYtS01ob/iwHzGRUDELlsoCftI/OZFhcLs1M0tkGPcXldE80TAZC5yYuJMBPJQQ43UHlqbJWiX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -4063,6 +5665,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4095,10 +5718,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
     },
@@ -4187,6 +5834,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4246,6 +5906,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "11.0.3",
@@ -4488,6 +6155,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
@@ -4528,6 +6205,144 @@
       },
       "engines": {
         "node": "^20.7.0 || ^22 || ^24"
+      }
+    },
+    "node_modules/homebridge-config-ui-x": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-5.17.0.tgz",
+      "integrity": "sha512-G1rGPxfxLvLuqGESGGBtzQZUL43IWJEbj3bCflNKrQobjuDajMZS0ZtMlbttIonphdub3ZSY25ghTCmd3hWLcA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/oznu"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/oznu"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/helmet": "13.0.2",
+        "@fastify/multipart": "9.4.0",
+        "@fastify/static": "9.0.0",
+        "@homebridge/hap-client": "3.3.0",
+        "@homebridge/node-pty-prebuilt-multiarch": "0.13.1",
+        "@nestjs/axios": "4.0.1",
+        "@nestjs/common": "11.1.13",
+        "@nestjs/core": "11.1.13",
+        "@nestjs/jwt": "11.0.2",
+        "@nestjs/passport": "11.0.5",
+        "@nestjs/platform-fastify": "11.1.13",
+        "@nestjs/platform-socket.io": "11.1.13",
+        "@nestjs/swagger": "11.2.6",
+        "@nestjs/websockets": "11.1.13",
+        "axios": "1.13.5",
+        "bash-color": "0.0.4",
+        "bonjour-service": "1.3.0",
+        "class-transformer": "0.5.1",
+        "class-validator": "0.14.3",
+        "commander": "14.0.3",
+        "dayjs": "1.11.19",
+        "fastify": "5.7.4",
+        "fs-extra": "11.3.3",
+        "jsonwebtoken": "9.0.3",
+        "lodash": "4.17.23",
+        "node-cache": "5.1.2",
+        "node-forge": "1.3.3",
+        "node-schedule": "2.1.1",
+        "ora": "9.3.0",
+        "otplib": "13.3.0",
+        "p-limit": "7.3.0",
+        "passport": "0.7.0",
+        "passport-jwt": "4.0.1",
+        "reflect-metadata": "0.2.2",
+        "rxjs": "7.8.2",
+        "semver": "7.7.4",
+        "systeminformation": "5.30.8",
+        "tail": "2.2.6",
+        "tar": "7.5.7",
+        "tcp-port-used": "1.0.2",
+        "unzipper": "0.12.3"
+      },
+      "bin": {
+        "hb-service": "dist/bin/hb-service.js"
+      },
+      "engines": {
+        "homebridge": "^1.8.0 || ^2.0.0-alpha.0",
+        "node": "^20.19.0 || ^22.12.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "macos-temperature-sensor": "1.0.4",
+        "osx-temperature-sensor": "1.0.8"
+      }
+    },
+    "node_modules/homebridge-config-ui-x/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/homebridge-config-ui-x/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/homebridge-config-ui-x/node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/homebridge-config-ui-x/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/homebridge-config-ui-x/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/homebridge-lib": {
@@ -4575,6 +6390,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4670,6 +6506,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflection": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-3.0.2.tgz",
+      "integrity": "sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4686,6 +6532,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -4709,6 +6562,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-arguments": {
@@ -4866,6 +6739,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -4995,6 +6881,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5021,6 +6927,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is2": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
+      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^4.1.0",
+        "is-url": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=v0.10.0"
       }
     },
     "node_modules/isarray": {
@@ -5116,6 +7037,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterare": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jackspeak": {
@@ -5969,6 +7900,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6009,6 +7960,52 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6043,12 +8040,78 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.37.tgz",
+      "integrity": "sha512-rDU6bkpuMs8YRt/UpkuYEAsYSoNuDEbrE41I3KNvmXREGH6DGBJ8Wbak4by29wNOQ27zk4g4HL82zf0OGhwRuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/load-esm": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+      "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=13.2.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -6066,6 +8129,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6080,12 +8192,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.2.2",
@@ -6096,6 +8239,30 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/macos-temperature-sensor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/macos-temperature-sensor/-/macos-temperature-sensor-1.0.4.tgz",
+      "integrity": "sha512-JROshGB+f+UnsbNwM6SER4AK82fdGmk79ElhH+8xVieCUQ1fxTanTwp7Rv9DTRtmgB6hLcEGvQYL8XsPbAKLUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -6177,6 +8344,42 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -6185,6 +8388,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -6210,13 +8439,26 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
@@ -6231,6 +8473,13 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mqtt": {
       "version": "5.14.1",
@@ -6306,6 +8555,13 @@
       "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
       "license": "MIT"
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -6329,12 +8585,65 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -6360,6 +8669,21 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-schedule": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.2.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.11",
@@ -6446,6 +8770,26 @@
         "js-sdsl": "4.3.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -6503,6 +8847,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6545,6 +8899,89 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/osx-temperature-sensor": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/osx-temperature-sensor/-/osx-temperature-sensor-1.0.8.tgz",
+      "integrity": "sha512-Gl3b+bn7+oDDnqPa+4v/cg3yg9lnE8ppS7ivL3opBZh4i7h99JNmkm6zWmo0m2a83UUJu+C9D7lGP0OS8IlehA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/otplib": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-13.3.0.tgz",
+      "integrity": "sha512-VYMKyyDG8yt2q+z58sz54/EIyTh7+tyMrjeemR44iVh5+dkKtIs57irTqxjH+IkAL1uMmG1JIFhG5CxTpqdU5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.3.0",
+        "@otplib/hotp": "13.3.0",
+        "@otplib/plugin-base32-scure": "13.3.0",
+        "@otplib/plugin-crypto-noble": "13.3.0",
+        "@otplib/totp": "13.3.0",
+        "@otplib/uri": "13.3.0"
       }
     },
     "node_modules/p-limit": {
@@ -6628,6 +9065,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6659,9 +9135,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6669,11 +9145,28 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
+      "dev": true
     },
     "node_modules/pause-stream": {
       "version": "0.0.11",
@@ -6707,6 +9200,46 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -6796,6 +9329,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6849,12 +9410,47 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6925,6 +9521,39 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -6961,6 +9590,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6985,6 +9631,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7022,6 +9678,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -7085,6 +9784,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -7122,12 +9831,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sax": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -7140,6 +9896,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7172,6 +9935,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7281,6 +10051,53 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -7314,6 +10131,72 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -7327,6 +10210,23 @@
         "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -7399,6 +10299,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
+      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -7608,6 +10531,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7619,6 +10559,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/synckit": {
@@ -7636,6 +10586,196 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.30.8",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.8.tgz",
+      "integrity": "sha512-imB8LwJCc2DkufKlSRHfzbjhheGzpg1P31A4c55IKTq/ll6Agn1rhBOY+WmS/hyg5inGFp7AyZIK0gvq5rFO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
+      }
+    },
+    "node_modules/tail": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/tail/-/tail-2.2.6.tgz",
+      "integrity": "sha512-IQ6G4wK/t8VBauYiGPLx+d3fA5XjSVagjWV5SIYzvEvglbQjwEcukeYI68JOPpdydjxhZ9sIgzRlSmwSpphHyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tcp-port-used": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -7674,6 +10814,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7705,6 +10858,45 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/touch": {
@@ -7846,6 +11038,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -7947,6 +11152,32 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -8005,6 +11236,20 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -8052,6 +11297,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -8083,6 +11338,26 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/walker": {
@@ -8503,6 +11778,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.46.4"
+    "typescript-eslint": "^8.46.4",
+    "homebridge-config-ui-x": "^5.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mp-consulting/homebridge-dyson-pure-cool",
   "displayName": "Dyson Pure Cool",
   "type": "module",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": false,
   "description": "Homebridge plugin for Dyson Pure Cool air purifiers and fans. Control fan speed, monitor air quality, temperature, and humidity via HomeKit.",
   "author": "MP Consulting",

--- a/src/accessories/dysonAccessory.ts
+++ b/src/accessories/dysonAccessory.ts
@@ -14,6 +14,7 @@ import type {
 
 import type { DysonDevice } from '../devices/dysonDevice.js';
 import type { DeviceState } from '../devices/types.js';
+import { getDeviceModelName } from '../config/index.js';
 
 /**
  * Configuration for DysonAccessory
@@ -168,22 +169,7 @@ export abstract class DysonAccessory {
    * Returns a human-readable model name based on product type.
    */
   private getModelName(): string {
-    const productType = this.device.productType;
-
-    const modelNames: Record<string, string> = {
-      '455': 'Pure Hot+Cool Link (HP02)',
-      '438': 'Pure Cool Tower (TP04)',
-      '438E': 'Purifier Cool (TP07)',
-      '469': 'Pure Cool Link Desk (DP01)',
-      '475': 'Pure Cool Link Tower (TP02)',
-      '520': 'Pure Cool Desk (DP04)',
-      '527': 'Pure Hot+Cool (HP04)',
-      '527E': 'Purifier Hot+Cool (HP07)',
-      '358': 'Pure Humidify+Cool (PH01)',
-      '358E': 'Pure Humidify+Cool (PH03)',
-    };
-
-    return modelNames[productType] || `Dyson (${productType})`;
+    return getDeviceModelName(this.device.productType);
   }
 
   /**

--- a/src/accessories/dysonAccessory.ts
+++ b/src/accessories/dysonAccessory.ts
@@ -40,6 +40,12 @@ export abstract class DysonAccessory {
   protected readonly api: API;
   protected readonly log: Logging;
 
+  /** Bound event handlers for cleanup */
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
+  private readonly boundHandleConnect: () => void;
+  private readonly boundHandleDisconnect: () => void;
+  private readonly boundHandleDebug: (message: string) => void;
+
   /**
    * Create a new DysonAccessory
    *
@@ -54,11 +60,16 @@ export abstract class DysonAccessory {
     // Set up AccessoryInformation service
     this.setupAccessoryInformation();
 
-    // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
-    this.device.on('connect', this.handleConnect.bind(this));
-    this.device.on('disconnect', this.handleDisconnect.bind(this));
-    this.device.on('debug', (message: string) => this.log.debug(message));
+    // Subscribe to device state changes (store bound refs for cleanup)
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.boundHandleConnect = this.handleConnect.bind(this);
+    this.boundHandleDisconnect = this.handleDisconnect.bind(this);
+    this.boundHandleDebug = (message: string) => this.log.debug(message);
+
+    this.device.on('stateChange', this.boundHandleStateChange);
+    this.device.on('connect', this.boundHandleConnect);
+    this.device.on('disconnect', this.boundHandleDisconnect);
+    this.device.on('debug', this.boundHandleDebug);
 
     // Set up device-specific services
     this.setupServices();
@@ -103,6 +114,19 @@ export abstract class DysonAccessory {
    */
   protected handleDisconnect(): void {
     this.log.warn('Device disconnected:', this.accessory.displayName);
+  }
+
+  /**
+   * Clean up event listeners
+   *
+   * Call this when the accessory is being removed to prevent
+   * EventEmitter listener leaks.
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
+    this.device.off('connect', this.boundHandleConnect);
+    this.device.off('disconnect', this.boundHandleDisconnect);
+    this.device.off('debug', this.boundHandleDebug);
   }
 
   /**

--- a/src/accessories/dysonLinkAccessory.ts
+++ b/src/accessories/dysonLinkAccessory.ts
@@ -348,6 +348,24 @@ export class DysonLinkAccessory extends DysonAccessory {
   }
 
   /**
+   * Clean up all service event listeners
+   */
+  override destroy(): void {
+    this.fanService?.destroy();
+    this.temperatureService?.destroy();
+    this.humidityService?.destroy();
+    this.nightModeService?.destroy();
+    this.continuousMonitoringService?.destroy();
+    this.airQualityService?.destroy();
+    this.filterService?.destroy();
+    this.thermostatService?.destroy();
+    this.humidifierControlService?.destroy();
+    this.jetFocusService?.destroy();
+    this.heaterCoolerService?.destroy();
+    super.destroy();
+  }
+
+  /**
    * Get the FanService instance
    */
   getFanService(): FanService {

--- a/src/accessories/dysonLinkAccessory.ts
+++ b/src/accessories/dysonLinkAccessory.ts
@@ -139,16 +139,20 @@ export class DysonLinkAccessory extends DysonAccessory {
    * @param config - Accessory configuration
    */
   constructor(config: DysonLinkAccessoryConfig) {
-    // Initialize options before super() call since setupServices() needs them
-    // The field initializer runs before super(), making options available
-    if (config.options) {
-      // Note: We need to set this before super() but after field initialization
-      // TypeScript doesn't allow this, so we use a default empty object above
-    }
+    // Store options BEFORE calling super(), because super() calls setupServices()
+    // which needs access to options. Field initializers run before super() in the
+    // JS runtime, so we can use Object.defineProperty to set it before super() runs.
+    // However, the simplest correct approach: store on the accessory context.
+    //
+    // We store options in the accessory context so setupServices() can access them,
+    // since TypeScript prevents assigning to `this` before `super()`.
+    config.accessory.context._deviceOptions = config.options ?? {};
+
     // Pass to parent - the base class will call setupServices()
     super(config as DysonAccessoryConfig);
-    // Update options after super (for any additional processing)
-    this.options = config.options ?? {};
+
+    // Also store as instance field for other methods
+    this.options = config.accessory.context._deviceOptions as DeviceOptions;
   }
 
   /**
@@ -159,7 +163,9 @@ export class DysonLinkAccessory extends DysonAccessory {
   protected setupServices(): void {
     const linkDevice = this.device as DysonLinkDevice;
     const features = linkDevice.getFeatures();
-    const opts = this.options ?? {};
+    // Read options from accessory context (set before super() call) to ensure
+    // they're available even though setupServices() is called during construction
+    const opts: DeviceOptions = (this.accessory.context._deviceOptions as DeviceOptions) ?? this.options ?? {};
     const deviceName = this.accessory.displayName;
 
     // Create FanService for fan control (all devices) - this is the primary service

--- a/src/accessories/dysonLinkAccessory.ts
+++ b/src/accessories/dysonLinkAccessory.ts
@@ -44,26 +44,14 @@ export interface DeviceOptions {
   isHumidityIgnored?: boolean;
   /** Disable air quality sensor */
   isAirQualityIgnored?: boolean;
-  /** Show temperature as separate accessory */
-  isTemperatureSensorEnabled?: boolean;
-  /** Show humidity as separate accessory */
-  isHumiditySensorEnabled?: boolean;
-  /** Show air quality as separate accessory */
-  isAirQualitySensorEnabled?: boolean;
 
   // Display options
   /** Use Fahrenheit for temperature display */
   useFahrenheit?: boolean;
-  /** Combine all services into single accessory */
-  isSingleAccessoryModeEnabled?: boolean;
-  /** Combine all sensors into single accessory */
-  isSingleSensorAccessoryModeEnabled?: boolean;
 
   // Heating options (HP models)
   /** Disable heating controls */
   isHeatingDisabled?: boolean;
-  /** Override heating safety restrictions */
-  isHeatingSafetyIgnored?: boolean;
   /**
    * Heating service type to expose in HomeKit
    * - 'thermostat': Traditional Thermostat service (matches reference plugin)
@@ -76,14 +64,6 @@ export interface DeviceOptions {
   /** Enable full humidity range (0-100%) for humidifier */
   fullRangeHumidity?: boolean;
 
-  // Activation behaviors
-  /** Enable auto mode on device activation */
-  enableAutoModeWhenActivating?: boolean;
-  /** Enable oscillation on device activation */
-  enableOscillationWhenActivating?: boolean;
-  /** Enable night mode on device activation */
-  enableNightModeWhenActivating?: boolean;
-
   // Service toggles
   /** Enable night mode switch */
   isNightModeEnabled?: boolean;
@@ -91,6 +71,10 @@ export interface DeviceOptions {
   isJetFocusEnabled?: boolean;
   /** Enable continuous monitoring switch */
   isContinuousMonitoringEnabled?: boolean;
+  /** Disable filter status service */
+  isFilterStatusDisabled?: boolean;
+  /** Disable humidifier control service */
+  isHumidifierDisabled?: boolean;
 }
 
 /**
@@ -242,8 +226,8 @@ export class DysonLinkAccessory extends DysonAccessory {
       });
     }
 
-    // Create FilterService if device has filters
-    if (features.hepaFilter || features.carbonFilter) {
+    // Create FilterService if device has filters and not disabled
+    if ((features.hepaFilter || features.carbonFilter) && !opts.isFilterStatusDisabled) {
       this.filterService = new FilterService({
         accessory: this.accessory,
         device: linkDevice,
@@ -281,8 +265,8 @@ export class DysonLinkAccessory extends DysonAccessory {
       }
     }
 
-    // Create HumidifierControlService for PH models
-    if (features.humidifier) {
+    // Create HumidifierControlService for PH models (if not disabled)
+    if (features.humidifier && !opts.isHumidifierDisabled) {
       this.humidifierControlService = new HumidifierControlService({
         accessory: this.accessory,
         device: linkDevice,

--- a/src/accessories/services/airQualityService.ts
+++ b/src/accessories/services/airQualityService.ts
@@ -142,7 +142,7 @@ export class AirQualityService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/airQualityService.ts
+++ b/src/accessories/services/airQualityService.ts
@@ -97,6 +97,7 @@ export class AirQualityService {
   private readonly api: API;
   private readonly hasNo2Sensor: boolean;
   private readonly basicAirQualitySensor: boolean;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: AirQualityServiceConfig) {
     this.device = config.device;
@@ -145,7 +146,8 @@ export class AirQualityService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('AirQualityService initialized for', config.accessory.displayName);
   }
@@ -155,6 +157,13 @@ export class AirQualityService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/continuousMonitoringService.ts
+++ b/src/accessories/services/continuousMonitoringService.ts
@@ -39,6 +39,7 @@ export class ContinuousMonitoringService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: ContinuousMonitoringServiceConfig) {
     this.device = config.device;
@@ -68,7 +69,8 @@ export class ContinuousMonitoringService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('ContinuousMonitoringService initialized for', config.accessory.displayName);
   }
@@ -78,6 +80,13 @@ export class ContinuousMonitoringService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/continuousMonitoringService.ts
+++ b/src/accessories/services/continuousMonitoringService.ts
@@ -65,7 +65,7 @@ export class ContinuousMonitoringService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/fanService.ts
+++ b/src/accessories/services/fanService.ts
@@ -78,6 +78,7 @@ export class FanService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   /** Timer for debouncing speed changes */
   private speedDebounceTimer?: ReturnType<typeof setTimeout>;
@@ -131,7 +132,8 @@ export class FanService {
       .onSet(this.handleSwingModeSet.bind(this));
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('FanService (AirPurifier) initialized for', config.accessory.displayName);
   }
@@ -141,6 +143,16 @@ export class FanService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners and timers
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
+    if (this.speedDebounceTimer) {
+      clearTimeout(this.speedDebounceTimer);
+    }
   }
 
   /**

--- a/src/accessories/services/fanService.ts
+++ b/src/accessories/services/fanService.ts
@@ -18,6 +18,7 @@ import type { DysonLinkDevice } from '../../devices/dysonLinkDevice.js';
 import type { DeviceState } from '../../devices/types.js';
 import { MessageCodec } from '../../protocol/messageCodec.js';
 
+
 /**
  * Configuration for FanService
  */
@@ -77,7 +78,6 @@ export class FanService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
-  private readonly codec: MessageCodec;
 
   /** Timer for debouncing speed changes */
   private speedDebounceTimer?: ReturnType<typeof setTimeout>;
@@ -88,7 +88,6 @@ export class FanService {
     this.device = config.device;
     this.log = config.log;
     this.api = config.api;
-    this.codec = new MessageCodec();
 
     const Service = this.api.hap.Service;
     const Characteristic = this.api.hap.Characteristic;
@@ -181,10 +180,10 @@ export class FanService {
     let currentState: number;
     if (!state.isOn) {
       currentState = AirPurifierState.INACTIVE;
-    } else if (state.fanSpeed === 0 || state.autoMode) {
-      // In auto mode or speed 0, consider it idle/monitoring
+    } else if (state.fanSpeed === 0) {
       currentState = AirPurifierState.IDLE;
     } else {
+      // Device is on and running (whether manual or auto mode)
       currentState = AirPurifierState.PURIFYING_AIR;
     }
 
@@ -225,7 +224,7 @@ export class FanService {
    */
   private handleSpeedGet(): CharacteristicValue {
     const state = this.device.getState();
-    const percent = this.codec.speedToPercent(state.fanSpeed);
+    const percent = MessageCodec.speedToPercent(state.fanSpeed);
     this.log.debug('Get RotationSpeed ->', percent);
     return percent;
   }
@@ -268,7 +267,7 @@ export class FanService {
         await this.device.setFanPower(false);
       } else {
         // Convert percentage to speed (1-10)
-        const speed = this.codec.percentToSpeed(percent);
+        const speed = MessageCodec.percentToSpeed(percent);
         await this.device.setFanSpeed(speed);
 
         // Also ensure fan is on when setting speed
@@ -328,7 +327,7 @@ export class FanService {
     let currentState: number;
     if (!state.isOn) {
       currentState = AirPurifierState.INACTIVE;
-    } else if (state.fanSpeed === 0 || state.autoMode) {
+    } else if (state.fanSpeed === 0) {
       currentState = AirPurifierState.IDLE;
     } else {
       currentState = AirPurifierState.PURIFYING_AIR;
@@ -345,7 +344,7 @@ export class FanService {
     );
 
     // Update RotationSpeed
-    const percent = this.codec.speedToPercent(state.fanSpeed);
+    const percent = MessageCodec.speedToPercent(state.fanSpeed);
     this.service.updateCharacteristic(
       Characteristic.RotationSpeed,
       percent,

--- a/src/accessories/services/fanService.ts
+++ b/src/accessories/services/fanService.ts
@@ -84,6 +84,8 @@ export class FanService {
   private speedDebounceTimer?: ReturnType<typeof setTimeout>;
   /** Pending speed value to be set after debounce */
   private pendingSpeed?: number;
+  /** Whether this service has been destroyed */
+  private destroyed = false;
 
   constructor(config: FanServiceConfig) {
     this.device = config.device;
@@ -149,6 +151,7 @@ export class FanService {
    * Clean up event listeners and timers
    */
   destroy(): void {
+    this.destroyed = true;
     this.device.off('stateChange', this.boundHandleStateChange);
     if (this.speedDebounceTimer) {
       clearTimeout(this.speedDebounceTimer);
@@ -265,6 +268,10 @@ export class FanService {
    * Apply the pending speed value after debounce delay
    */
   private async applyPendingSpeed(): Promise<void> {
+    if (this.destroyed) {
+      return;
+    }
+
     const percent = this.pendingSpeed;
     if (percent === undefined) {
       return;

--- a/src/accessories/services/filterService.ts
+++ b/src/accessories/services/filterService.ts
@@ -79,7 +79,7 @@ export class FilterService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/filterService.ts
+++ b/src/accessories/services/filterService.ts
@@ -51,6 +51,7 @@ export class FilterService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: FilterServiceConfig) {
     this.device = config.device;
@@ -82,7 +83,8 @@ export class FilterService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('FilterService initialized for', config.accessory.displayName);
   }
@@ -92,6 +94,13 @@ export class FilterService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/heaterCoolerService.ts
+++ b/src/accessories/services/heaterCoolerService.ts
@@ -156,7 +156,7 @@ export class HeaterCoolerService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes
@@ -344,7 +344,7 @@ export class HeaterCoolerService {
     } else {
       const currentTemp = this.convertTemperature(state.temperature);
       const targetTemp = this.convertTargetTemperature(state.targetTemperature);
-      currentState = currentTemp < targetTemp - 0.5
+      currentState = currentTemp < targetTemp - HEATING_TOLERANCE_CELSIUS
         ? this.CURRENT_STATE.HEATING
         : this.CURRENT_STATE.IDLE;
     }

--- a/src/accessories/services/heaterCoolerService.ts
+++ b/src/accessories/services/heaterCoolerService.ts
@@ -80,6 +80,7 @@ export class HeaterCoolerService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   // HomeKit HeaterCooler state constants
   private readonly CURRENT_STATE = {
@@ -159,7 +160,8 @@ export class HeaterCoolerService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('HeaterCoolerService initialized for', config.accessory.displayName);
   }
@@ -169,6 +171,13 @@ export class HeaterCoolerService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/humidifierControlService.ts
+++ b/src/accessories/services/humidifierControlService.ts
@@ -60,6 +60,7 @@ export class HumidifierControlService {
   private readonly api: API;
   private readonly humidityMin: number;
   private readonly humidityMax: number;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: HumidifierControlServiceConfig) {
     this.device = config.device;
@@ -133,7 +134,8 @@ export class HumidifierControlService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('HumidifierControlService initialized for', config.accessory.displayName);
   }
@@ -143,6 +145,13 @@ export class HumidifierControlService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/humidifierControlService.ts
+++ b/src/accessories/services/humidifierControlService.ts
@@ -130,7 +130,7 @@ export class HumidifierControlService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/humidityService.ts
+++ b/src/accessories/services/humidityService.ts
@@ -83,7 +83,7 @@ export class HumidityService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/humidityService.ts
+++ b/src/accessories/services/humidityService.ts
@@ -53,6 +53,7 @@ export class HumidityService {
   private readonly log: Logging;
   private readonly api: API;
   private readonly humidityOffset: number;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: HumidityServiceConfig) {
     this.device = config.device;
@@ -86,7 +87,8 @@ export class HumidityService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('HumidityService initialized for', config.accessory.displayName);
   }
@@ -96,6 +98,13 @@ export class HumidityService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/jetFocusService.ts
+++ b/src/accessories/services/jetFocusService.ts
@@ -64,7 +64,7 @@ export class JetFocusService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/jetFocusService.ts
+++ b/src/accessories/services/jetFocusService.ts
@@ -38,6 +38,7 @@ export class JetFocusService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: JetFocusServiceConfig) {
     this.device = config.device;
@@ -67,7 +68,8 @@ export class JetFocusService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('JetFocusService initialized for', config.accessory.displayName);
   }
@@ -77,6 +79,13 @@ export class JetFocusService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/nightModeService.ts
+++ b/src/accessories/services/nightModeService.ts
@@ -65,7 +65,7 @@ export class NightModeService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes
@@ -95,8 +95,9 @@ export class NightModeService {
    */
   private handleOnGet(): CharacteristicValue {
     const state = this.device.getState();
-    this.log.debug('Get Night Mode ->', state.nightMode);
-    return state.nightMode;
+    const nightMode = state.nightMode ?? false;
+    this.log.debug('Get Night Mode ->', nightMode);
+    return nightMode;
   }
 
   /**
@@ -123,7 +124,7 @@ export class NightModeService {
     this.log.debug('Night mode state changed ->', state.nightMode);
 
     const Characteristic = this.api.hap.Characteristic;
-    this.service.updateCharacteristic(Characteristic.On, state.nightMode);
+    this.service.updateCharacteristic(Characteristic.On, state.nightMode ?? false);
   }
 
   /**

--- a/src/accessories/services/nightModeService.ts
+++ b/src/accessories/services/nightModeService.ts
@@ -39,6 +39,7 @@ export class NightModeService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: NightModeServiceConfig) {
     this.device = config.device;
@@ -68,7 +69,8 @@ export class NightModeService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('NightModeService initialized for', config.accessory.displayName);
   }
@@ -78,6 +80,13 @@ export class NightModeService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/temperatureService.ts
+++ b/src/accessories/services/temperatureService.ts
@@ -45,6 +45,7 @@ export class TemperatureService {
   private readonly api: API;
   private readonly temperatureOffset: number;
   private readonly useFahrenheit: boolean;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: TemperatureServiceConfig) {
     this.device = config.device;
@@ -79,7 +80,8 @@ export class TemperatureService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('TemperatureService initialized for', config.accessory.displayName);
   }
@@ -89,6 +91,13 @@ export class TemperatureService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/temperatureService.ts
+++ b/src/accessories/services/temperatureService.ts
@@ -76,7 +76,7 @@ export class TemperatureService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/accessories/services/thermostatService.ts
+++ b/src/accessories/services/thermostatService.ts
@@ -48,6 +48,7 @@ export class ThermostatService {
   private readonly device: DysonLinkDevice;
   private readonly log: Logging;
   private readonly api: API;
+  private readonly boundHandleStateChange: (state: DeviceState) => void;
 
   constructor(config: ThermostatServiceConfig) {
     this.device = config.device;
@@ -113,7 +114,8 @@ export class ThermostatService {
     }
 
     // Subscribe to device state changes
-    this.device.on('stateChange', this.handleStateChange.bind(this));
+    this.boundHandleStateChange = this.handleStateChange.bind(this);
+    this.device.on('stateChange', this.boundHandleStateChange);
 
     this.log.debug('ThermostatService initialized for', config.accessory.displayName);
   }
@@ -123,6 +125,13 @@ export class ThermostatService {
    */
   getService(): Service {
     return this.service;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    this.device.off('stateChange', this.boundHandleStateChange);
   }
 
   /**

--- a/src/accessories/services/thermostatService.ts
+++ b/src/accessories/services/thermostatService.ts
@@ -110,7 +110,7 @@ export class ThermostatService {
 
     // Link to primary service if provided
     if (config.primaryService) {
-      this.service.addLinkedService(config.primaryService);
+      config.primaryService.addLinkedService(this.service);
     }
 
     // Subscribe to device state changes

--- a/src/config/deviceCatalog.ts
+++ b/src/config/deviceCatalog.ts
@@ -13,7 +13,7 @@ import { DEFAULT_FEATURES } from '../devices/types.js';
  */
 export type DeviceSeries =
   | 'pure-cool-link'      // TP02, DP01 (older Link series)
-  | 'pure-cool'           // TP04, TP07, TP09, TP11, DP04
+  | 'pure-cool'           // TP04, TP06, TP07, TP09, TP11, DP04
   | 'hot-cool-link'       // HP02 (older Link series)
   | 'hot-cool'            // HP04, HP06, HP07, HP09, HP11
   | 'humidify-cool'       // PH01, PH02, PH03, PH04
@@ -187,7 +187,7 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
   {
     productType: '438',
     modelName: 'Dyson Pure Cool Tower',
-    modelCode: 'TP04',
+    modelCode: 'TP04', // Also covers TP06 (Cryptomic) which shares the same product type
     series: 'pure-cool',
     features: FEATURES_PURE_COOL_JET,
     formaldehyde: false,

--- a/src/devices/dysonDevice.ts
+++ b/src/devices/dysonDevice.ts
@@ -220,9 +220,13 @@ export abstract class DysonDevice extends EventEmitter {
     // Start periodic polling for state updates
     this.startPolling();
 
-    // Update connection state
-    this.updateState({ connected: true });
-    this.emit('connect');
+    // Set connected state if the MQTT handler hasn't already done so
+    // (the real MQTT client emits 'connect' during await connect(), but
+    // this guard ensures correctness regardless of timing)
+    if (!this.state.connected) {
+      this.updateState({ connected: true });
+      this.emit('connect');
+    }
   }
 
   /**

--- a/src/devices/dysonDevice.ts
+++ b/src/devices/dysonDevice.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from 'events';
 
 import { DysonMqttClient } from '../protocol/mqttClient.js';
 import type { MqttMessage, MqttConnectFn } from '../protocol/mqttClient.js';
+import { MessageCodec } from '../protocol/messageCodec.js';
 
 import type {
   DeviceInfo,
@@ -347,125 +348,15 @@ export abstract class DysonDevice extends EventEmitter {
   /**
    * Handle environmental sensor data
    *
-   * Can be overridden by subclasses that support environmental sensors.
+   * Delegates to MessageCodec.parseEnvironmentalData for consistent parsing.
    *
    * @param data - Parsed sensor data
    */
   protected handleEnvironmentalMessage(data: Record<string, unknown>): void {
-    // Default implementation - subclasses can override
-    const sensorData = (data.data as Record<string, unknown>) || data;
-
+    const sensorData = (data.data as Record<string, string>) || data;
     const stateUpdate: Partial<DeviceState> = {};
 
-    // Temperature (in Kelvin * 10)
-    if ('tact' in sensorData) {
-      const temp = sensorData.tact;
-      if (typeof temp === 'string' && temp !== 'OFF') {
-        const value = parseInt(temp, 10);
-        if (!isNaN(value)) {
-          stateUpdate.temperature = value;
-        }
-      }
-    }
-
-    // Humidity percentage
-    if ('hact' in sensorData) {
-      const humidity = sensorData.hact;
-      if (typeof humidity === 'string' && humidity !== 'OFF') {
-        const value = parseInt(humidity, 10);
-        if (!isNaN(value)) {
-          stateUpdate.humidity = value;
-        }
-      }
-    }
-
-    // PM2.5 - newer models use p25r, older Link models use pact
-    if ('p25r' in sensorData) {
-      const pm25 = sensorData.p25r;
-      if (typeof pm25 === 'string' && pm25 !== 'INIT' && pm25 !== 'OFF') {
-        const value = parseInt(pm25, 10);
-        if (!isNaN(value)) {
-          stateUpdate.pm25 = value;
-        }
-      }
-    } else if ('pact' in sensorData) {
-      // Older Link series (HP02, TP02) use pact for particulate matter
-      const pact = sensorData.pact;
-      if (typeof pact === 'string' && pact !== 'INIT' && pact !== 'OFF') {
-        const value = parseInt(pact, 10);
-        if (!isNaN(value)) {
-          stateUpdate.pm25 = value;
-        }
-      }
-    }
-
-    // PM10 - only on newer models (p10r field)
-    if ('p10r' in sensorData) {
-      const pm10 = sensorData.p10r;
-      if (typeof pm10 === 'string' && pm10 !== 'INIT' && pm10 !== 'OFF') {
-        const value = parseInt(pm10, 10);
-        if (!isNaN(value)) {
-          stateUpdate.pm10 = value;
-        }
-      }
-    }
-
-    // VOC index - newer models use va10, older Link models use vact
-    if ('va10' in sensorData) {
-      const voc = sensorData.va10;
-      if (typeof voc === 'string' && voc !== 'INIT' && voc !== 'OFF') {
-        const value = parseInt(voc, 10);
-        if (!isNaN(value)) {
-          stateUpdate.vocIndex = value;
-        }
-      }
-    } else if ('vact' in sensorData) {
-      // Older Link series (HP02, TP02) use vact for VOC
-      const vact = sensorData.vact;
-      if (typeof vact === 'string' && vact !== 'INIT' && vact !== 'OFF') {
-        const value = parseInt(vact, 10);
-        if (!isNaN(value)) {
-          stateUpdate.vocIndex = value;
-        }
-      }
-    }
-
-    // NO2 index - only on newer models with formaldehyde sensor
-    if ('noxl' in sensorData) {
-      const no2 = sensorData.noxl;
-      if (typeof no2 === 'string' && no2 !== 'INIT' && no2 !== 'OFF') {
-        const value = parseInt(no2, 10);
-        if (!isNaN(value)) {
-          stateUpdate.no2Index = value;
-        }
-      }
-    }
-
-    // Formaldehyde (HCHO) level - only on formaldehyde models
-    if ('hchr' in sensorData) {
-      const hchr = sensorData.hchr;
-      if (typeof hchr === 'string' && hchr !== 'INIT' && hchr !== 'OFF') {
-        const value = parseInt(hchr, 10);
-        if (!isNaN(value)) {
-          stateUpdate.formaldehydeLevel = value;
-        }
-      }
-    }
-
-    // Sleep timer
-    if ('sltm' in sensorData) {
-      const sltm = sensorData.sltm;
-      if (typeof sltm === 'string') {
-        if (sltm === 'OFF') {
-          stateUpdate.sleepTimer = 0;
-        } else {
-          const value = parseInt(sltm, 10);
-          if (!isNaN(value)) {
-            stateUpdate.sleepTimer = value;
-          }
-        }
-      }
-    }
+    MessageCodec.parseEnvironmentalData(sensorData, stateUpdate);
 
     if (Object.keys(stateUpdate).length > 0) {
       this.updateState(stateUpdate);

--- a/src/devices/dysonDevice.ts
+++ b/src/devices/dysonDevice.ts
@@ -164,6 +164,9 @@ export abstract class DysonDevice extends EventEmitter {
         });
       }
     }, this.pollingIntervalMs);
+
+    // Don't keep the Node.js process alive just for polling
+    this.pollingIntervalHandle.unref();
   }
 
   /**

--- a/src/devices/dysonLinkDevice.ts
+++ b/src/devices/dysonLinkDevice.ts
@@ -42,6 +42,9 @@ export class DysonLinkDevice extends DysonDevice {
   /** Whether a command flush is scheduled */
   private commandFlushScheduled = false;
 
+  /** Whether a power-off is in progress (prevents concurrent commands from overriding OFF) */
+  private turningOff = false;
+
   /**
    * Create a new DysonLinkDevice
    *
@@ -108,6 +111,7 @@ export class DysonLinkDevice extends DysonDevice {
    */
   async setFanPower(on: boolean): Promise<void> {
     if (on) {
+      this.turningOff = false;
       // If already on, skip to avoid overriding mode changes
       // (HomeKit often sends Active=true along with mode changes)
       if (this.state.isOn) {
@@ -130,10 +134,20 @@ export class DysonLinkDevice extends DysonDevice {
         }
       }
     } else {
-      if (this.isLinkSeries) {
-        this.queueCommand({ fpwr: PROTOCOL.OFF });
-      } else {
-        this.queueCommand({ fmod: PROTOCOL.OFF });
+      // Power off: send directly to prevent concurrent mode changes
+      // (e.g. TargetAirPurifierState) from overwriting the OFF command
+      // via command batching. The turningOff flag prevents other methods
+      // called in the same tick from queuing commands that override OFF.
+      this.turningOff = true;
+      this.pendingCommandFields = {};
+      try {
+        if (this.isLinkSeries) {
+          await this.sendCommand({ fpwr: PROTOCOL.OFF });
+        } else {
+          await this.sendCommand({ fmod: PROTOCOL.OFF });
+        }
+      } finally {
+        this.turningOff = false;
       }
     }
   }
@@ -144,6 +158,9 @@ export class DysonLinkDevice extends DysonDevice {
    * @param speed - Fan speed (1-10) or -1 for auto mode
    */
   async setFanSpeed(speed: number): Promise<void> {
+    if (this.turningOff) {
+      return;
+    }
     if (this.isLinkSeries) {
       if (speed < 0) {
         this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
@@ -188,6 +205,9 @@ export class DysonLinkDevice extends DysonDevice {
    * Set auto mode on or off
    */
   async setAutoMode(on: boolean): Promise<void> {
+    if (this.turningOff) {
+      return;
+    }
     if (this.isLinkSeries) {
       if (on) {
         this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });

--- a/src/devices/dysonLinkDevice.ts
+++ b/src/devices/dysonLinkDevice.ts
@@ -274,6 +274,16 @@ export class DysonLinkDevice extends DysonDevice {
   }
 
   /**
+   * Disconnect from the device, clearing any pending commands
+   */
+  override async disconnect(): Promise<void> {
+    // Clear pending commands to prevent stale fields from being sent on reconnect
+    this.pendingCommandFields = {};
+    this.commandFlushScheduled = false;
+    await super.disconnect();
+  }
+
+  /**
    * Get the device features
    */
   getFeatures(): DeviceFeatures {

--- a/src/devices/dysonLinkDevice.ts
+++ b/src/devices/dysonLinkDevice.ts
@@ -74,7 +74,11 @@ export class DysonLinkDevice extends DysonDevice {
 
     if (!this.commandFlushScheduled) {
       this.commandFlushScheduled = true;
-      queueMicrotask(() => this.flushCommand());
+      queueMicrotask(() => {
+        this.flushCommand().catch((error) => {
+          this.emit('error', error instanceof Error ? error : new Error(String(error)));
+        });
+      });
     }
   }
 

--- a/src/devices/dysonLinkDevice.ts
+++ b/src/devices/dysonLinkDevice.ts
@@ -7,61 +7,24 @@
 
 import { DysonDevice } from './dysonDevice.js';
 import type { DeviceFeatures, DeviceInfo } from './types.js';
-import { MessageCodec } from '../protocol/messageCodec.js';
+import { MessageCodec, FAN_SPEED, HEATING_TEMP, HUMIDITY, PROTOCOL, FORMAT, TEMPERATURE } from '../protocol/messageCodec.js';
 import type { MqttClientFactory } from './dysonDevice.js';
 import type { MqttConnectFn } from '../protocol/mqttClient.js';
 import { getDeviceFeatures } from '../config/index.js';
 
 // ============================================================================
-// Constants - No Magic Numbers
-// ============================================================================
-
-/** Fan speed limits */
-const FAN_SPEED = {
-  MIN: 1,
-  MAX: 10,
-  DEFAULT: 4,
-  AUTO: -1,
-} as const;
-
-/** Temperature limits for heating (Celsius) */
-const HEATING_TEMP = {
-  MIN_CELSIUS: 1,
-  MAX_CELSIUS: 37,
-  KELVIN_OFFSET: 273.15,
-  KELVIN_MULTIPLIER: 10,
-} as const;
-
-/** Humidity limits for humidifier */
-const HUMIDITY = {
-  MIN_PERCENT: 0,
-  MAX_PERCENT: 100,
-  DEFAULT_MIN: 30,
-  DEFAULT_MAX: 70,
-} as const;
-
-/** Dyson protocol values */
-const PROTOCOL = {
-  ON: 'ON',
-  OFF: 'OFF',
-  AUTO: 'AUTO',
-  FAN: 'FAN',
-  HEAT: 'HEAT',
-  SPEED_PAD_LENGTH: 4,
-} as const;
-
-// ============================================================================
 // DysonLinkDevice
 // ============================================================================
-
-/** Delay in ms to wait for mode changes before sending power-on command */
-const POWER_ON_DELAY_MS = 50;
 
 /**
  * Dyson Link Device implementation
  *
  * Handles fan control for all Dyson purifier devices.
  * Features are determined by the device catalog based on product type.
+ *
+ * Commands are batched within a microtask to allow concurrent HomeKit
+ * characteristic updates (e.g., Active + TargetState) to be merged
+ * into a single MQTT command.
  */
 export class DysonLinkDevice extends DysonDevice {
   /** Product type for this device */
@@ -73,14 +36,11 @@ export class DysonLinkDevice extends DysonDevice {
   /** Whether this is a Link series device (uses different protocol) */
   private readonly isLinkSeries: boolean;
 
-  /** Message codec for encoding/decoding */
-  private readonly codec: MessageCodec;
+  /** Pending command fields to be batched and sent */
+  private pendingCommandFields: Record<string, string> = {};
 
-  /** Pending power-on timer to allow mode changes to arrive first */
-  private pendingPowerOnTimer?: ReturnType<typeof setTimeout>;
-
-  /** Flag to track if a mode change is pending */
-  private pendingModeChange = false;
+  /** Whether a command flush is scheduled */
+  private commandFlushScheduled = false;
 
   /**
    * Create a new DysonLinkDevice
@@ -97,7 +57,6 @@ export class DysonLinkDevice extends DysonDevice {
     super(deviceInfo, mqttClientFactory, mqttConnectFn);
     this.productType = deviceInfo.productType;
     this.supportedFeatures = getDeviceFeatures(deviceInfo.productType);
-    this.codec = new MessageCodec();
 
     // Check if this is a Pure Cool Link device (TP02, DP01) - uses fpwr/auto protocol
     // Note: HP02 (455) is called "Hot+Cool Link" but uses fmod like newer devices
@@ -106,72 +65,71 @@ export class DysonLinkDevice extends DysonDevice {
   }
 
   /**
+   * Queue command fields to be sent. Fields are merged and flushed
+   * on the next microtask, allowing concurrent HomeKit updates to
+   * produce a single MQTT command.
+   */
+  private queueCommand(fields: Record<string, string>): void {
+    Object.assign(this.pendingCommandFields, fields);
+
+    if (!this.commandFlushScheduled) {
+      this.commandFlushScheduled = true;
+      queueMicrotask(() => this.flushCommand());
+    }
+  }
+
+  /**
+   * Flush all pending command fields as a single MQTT command
+   */
+  private async flushCommand(): Promise<void> {
+    this.commandFlushScheduled = false;
+    const fields = this.pendingCommandFields;
+    this.pendingCommandFields = {};
+
+    if (Object.keys(fields).length > 0) {
+      try {
+        await this.sendCommand(fields);
+      } catch (error) {
+        this.emit('commandError', error);
+      }
+    }
+  }
+
+  /**
    * Set fan power on or off
    *
-   * Uses fmod command for newer models, fmod/fnsp for Link series.
-   * When turning on, delays briefly to allow concurrent mode changes to arrive first.
+   * Uses fmod command for newer models, fpwr/auto/fnsp for Link series.
    *
    * @param on - True to turn on, false to turn off
    */
   async setFanPower(on: boolean): Promise<void> {
     if (on) {
-      // If already on, don't send anything to avoid overriding mode changes
+      // If already on, skip to avoid overriding mode changes
       // (HomeKit often sends Active=true along with mode changes)
       if (this.state.isOn) {
         return;
       }
 
-      // Clear any pending power-on timer
-      if (this.pendingPowerOnTimer) {
-        clearTimeout(this.pendingPowerOnTimer);
-      }
-
-      // Mark that we have a pending power-on, and delay briefly
-      // This allows setAutoMode to be called first if HomeKit sends both together
-      this.pendingModeChange = false;
-
-      await new Promise<void>((resolve) => {
-        this.pendingPowerOnTimer = setTimeout(async () => {
-          this.pendingPowerOnTimer = undefined;
-
-          // If a mode change happened during the delay, it already turned on the device
-          if (this.pendingModeChange || this.state.isOn) {
-            resolve();
-            return;
-          }
-
-          // No mode change came, turn on with current auto mode setting
-          if (this.isLinkSeries) {
-            // Link series uses 'fpwr', 'auto', and 'fnsp'
-            if (this.state.autoMode) {
-              await this.sendCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
-            } else {
-              const speed = this.state.fanSpeed > 0 ? this.state.fanSpeed : FAN_SPEED.DEFAULT;
-              const encodedSpeed = String(speed).padStart(PROTOCOL.SPEED_PAD_LENGTH, '0');
-              await this.sendCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.OFF, fnsp: encodedSpeed });
-            }
-          } else {
-            // Newer models use 'fmod'
-            if (this.state.autoMode) {
-              await this.sendCommand({ fmod: PROTOCOL.AUTO });
-            } else {
-              await this.sendCommand({ fmod: PROTOCOL.FAN });
-            }
-          }
-          resolve();
-        }, POWER_ON_DELAY_MS);
-      });
-    } else {
-      // Turn off - cancel any pending power-on
-      if (this.pendingPowerOnTimer) {
-        clearTimeout(this.pendingPowerOnTimer);
-        this.pendingPowerOnTimer = undefined;
-      }
       if (this.isLinkSeries) {
-        // Link series: use fpwr to turn off
-        await this.sendCommand({ fpwr: PROTOCOL.OFF });
+        if (this.state.autoMode) {
+          this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
+        } else {
+          const speed = this.state.fanSpeed > 0 ? this.state.fanSpeed : FAN_SPEED.DEFAULT;
+          const encodedSpeed = String(speed).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
+          this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.OFF, fnsp: encodedSpeed });
+        }
       } else {
-        await this.sendCommand({ fmod: PROTOCOL.OFF });
+        if (this.state.autoMode) {
+          this.queueCommand({ fmod: PROTOCOL.AUTO });
+        } else {
+          this.queueCommand({ fmod: PROTOCOL.FAN });
+        }
+      }
+    } else {
+      if (this.isLinkSeries) {
+        this.queueCommand({ fpwr: PROTOCOL.OFF });
+      } else {
+        this.queueCommand({ fmod: PROTOCOL.OFF });
       }
     }
   }
@@ -183,115 +141,85 @@ export class DysonLinkDevice extends DysonDevice {
    */
   async setFanSpeed(speed: number): Promise<void> {
     if (this.isLinkSeries) {
-      // Link series uses 'fpwr', 'auto' and 'fnsp'
       if (speed < 0) {
-        await this.sendCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
+        this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
       } else {
         const clampedSpeed = Math.max(FAN_SPEED.MIN, Math.min(FAN_SPEED.MAX, speed));
-        const encodedSpeed = String(clampedSpeed).padStart(PROTOCOL.SPEED_PAD_LENGTH, '0');
-        await this.sendCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.OFF, fnsp: encodedSpeed });
+        const encodedSpeed = String(clampedSpeed).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
+        this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.OFF, fnsp: encodedSpeed });
       }
     } else {
-      // Newer models use 'fmod'
       if (speed < 0) {
-        await this.sendCommand({ fmod: PROTOCOL.AUTO });
+        this.queueCommand({ fmod: PROTOCOL.AUTO });
       } else {
         const clampedSpeed = Math.max(FAN_SPEED.MIN, Math.min(FAN_SPEED.MAX, speed));
-        const encodedSpeed = String(clampedSpeed).padStart(PROTOCOL.SPEED_PAD_LENGTH, '0');
-        await this.sendCommand({ fnsp: encodedSpeed, fmod: PROTOCOL.FAN });
+        const encodedSpeed = String(clampedSpeed).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
+        this.queueCommand({ fnsp: encodedSpeed, fmod: PROTOCOL.FAN });
       }
     }
   }
 
   /**
    * Set oscillation on or off
-   *
-   * @param on - True to enable oscillation, false to disable
    */
   async setOscillation(on: boolean): Promise<void> {
-    await this.sendCommand({ oson: on ? PROTOCOL.ON : PROTOCOL.OFF });
+    this.queueCommand({ oson: on ? PROTOCOL.ON : PROTOCOL.OFF });
   }
 
   /**
    * Set night mode on or off
-   *
-   * @param on - True to enable night mode, false to disable
    */
   async setNightMode(on: boolean): Promise<void> {
-    await this.sendCommand({ nmod: on ? PROTOCOL.ON : PROTOCOL.OFF });
+    this.queueCommand({ nmod: on ? PROTOCOL.ON : PROTOCOL.OFF });
   }
 
   /**
    * Set continuous monitoring on or off
-   *
-   * When enabled, sensors remain active even when the fan is off.
-   *
-   * @param on - True to enable continuous monitoring, false to disable
    */
   async setContinuousMonitoring(on: boolean): Promise<void> {
-    await this.sendCommand({ rhtm: on ? PROTOCOL.ON : PROTOCOL.OFF });
+    this.queueCommand({ rhtm: on ? PROTOCOL.ON : PROTOCOL.OFF });
   }
 
   /**
    * Set auto mode on or off
-   *
-   * @param on - True to enable auto mode, false to disable
    */
   async setAutoMode(on: boolean): Promise<void> {
-    // Cancel any pending power-on since we'll handle power state here
-    if (this.pendingPowerOnTimer) {
-      clearTimeout(this.pendingPowerOnTimer);
-      this.pendingPowerOnTimer = undefined;
-    }
-    this.pendingModeChange = true;
-
     if (this.isLinkSeries) {
-      // Link series (HP02, TP02, DP01) uses 'fpwr', 'auto' field and 'fnsp' for speed
       if (on) {
-        await this.sendCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
+        this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
       } else {
         const currentSpeed = this.state.fanSpeed > 0 ? this.state.fanSpeed : FAN_SPEED.DEFAULT;
-        const encodedSpeed = String(currentSpeed).padStart(PROTOCOL.SPEED_PAD_LENGTH, '0');
-        await this.sendCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.OFF, fnsp: encodedSpeed });
+        const encodedSpeed = String(currentSpeed).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
+        this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.OFF, fnsp: encodedSpeed });
       }
     } else {
-      // Newer models (TP04, HP04, etc.) use 'fmod' field
       if (on) {
-        await this.sendCommand({ fmod: PROTOCOL.AUTO });
+        this.queueCommand({ fmod: PROTOCOL.AUTO });
       } else {
         const currentSpeed = this.state.fanSpeed > 0 ? this.state.fanSpeed : FAN_SPEED.DEFAULT;
-        const encodedSpeed = String(currentSpeed).padStart(PROTOCOL.SPEED_PAD_LENGTH, '0');
-        await this.sendCommand({ fmod: PROTOCOL.FAN, fnsp: encodedSpeed });
+        const encodedSpeed = String(currentSpeed).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
+        this.queueCommand({ fmod: PROTOCOL.FAN, fnsp: encodedSpeed });
       }
     }
   }
 
   /**
    * Set jet focus (front airflow direction) on or off
-   *
-   * When enabled, air is directed in a focused stream.
-   * When disabled, air is diffused for whole-room circulation.
-   *
-   * @param on - True to enable jet focus, false to disable
    */
   async setJetFocus(on: boolean): Promise<void> {
-    await this.sendCommand({ ffoc: on ? PROTOCOL.ON : PROTOCOL.OFF });
+    this.queueCommand({ ffoc: on ? PROTOCOL.ON : PROTOCOL.OFF });
   }
 
   /**
    * Set heating mode on or off (HP models only)
-   *
-   * @param on - True to enable heating, false to disable
    */
   async setHeating(on: boolean): Promise<void> {
-    await this.sendCommand({ hmod: on ? PROTOCOL.HEAT : PROTOCOL.OFF });
+    this.queueCommand({ hmod: on ? PROTOCOL.HEAT : PROTOCOL.OFF });
   }
 
   /**
    * Set heating mode on or off (HP-series only)
    * Alias for setHeating with feature check.
-   *
-   * @param on - True to enable heating, false to disable
    */
   async setHeatingMode(on: boolean): Promise<void> {
     if (!this.supportedFeatures.heating) {
@@ -306,34 +234,28 @@ export class DysonLinkDevice extends DysonDevice {
    * @param celsius - Target temperature in Celsius (1-37)
    */
   async setTargetTemperature(celsius: number): Promise<void> {
-    // Clamp to valid range
     const clampedTemp = Math.max(
       HEATING_TEMP.MIN_CELSIUS,
       Math.min(HEATING_TEMP.MAX_CELSIUS, celsius),
     );
-    // Convert to Kelvin * 10
     const kelvinTimes10 = Math.round(
-      (clampedTemp + HEATING_TEMP.KELVIN_OFFSET) * HEATING_TEMP.KELVIN_MULTIPLIER,
+      (clampedTemp + TEMPERATURE.KELVIN_OFFSET) * TEMPERATURE.KELVIN_MULTIPLIER,
     );
-    await this.sendCommand({ hmax: String(kelvinTimes10) });
+    this.queueCommand({ hmax: String(kelvinTimes10) });
   }
 
   /**
    * Set humidifier mode on or off (PH models only)
-   *
-   * @param on - True to enable humidifier, false to disable
    */
   async setHumidifier(on: boolean): Promise<void> {
-    await this.sendCommand({ hume: on ? PROTOCOL.ON : PROTOCOL.OFF });
+    this.queueCommand({ hume: on ? PROTOCOL.ON : PROTOCOL.OFF });
   }
 
   /**
    * Set humidifier to auto mode (PH models only)
-   *
-   * In auto mode, the humidifier maintains optimal humidity automatically.
    */
   async setHumidifierAuto(): Promise<void> {
-    await this.sendCommand({ hume: PROTOCOL.AUTO });
+    this.queueCommand({ hume: PROTOCOL.AUTO });
   }
 
   /**
@@ -346,15 +268,13 @@ export class DysonLinkDevice extends DysonDevice {
       HUMIDITY.MIN_PERCENT,
       Math.min(HUMIDITY.MAX_PERCENT, Math.round(percent)),
     );
-    await this.sendCommand({
-      humt: String(clampedPercent).padStart(PROTOCOL.SPEED_PAD_LENGTH, '0'),
+    this.queueCommand({
+      humt: String(clampedPercent).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR),
     });
   }
 
   /**
    * Get the device features
-   *
-   * @returns DeviceFeatures object describing what this device supports
    */
   getFeatures(): DeviceFeatures {
     return this.supportedFeatures;
@@ -364,11 +284,8 @@ export class DysonLinkDevice extends DysonDevice {
    * Handle state message from device
    *
    * Parses the device-specific state from CURRENT-STATE and STATE-CHANGE messages.
-   *
-   * @param data - Parsed message data
    */
   protected handleStateMessage(data: Record<string, unknown>): void {
-    // Get state data from 'product-state' or 'data' field
     const productState = (data['product-state'] as Record<string, string>) ||
                          (data.data as Record<string, string>);
 
@@ -376,16 +293,12 @@ export class DysonLinkDevice extends DysonDevice {
       return;
     }
 
-    // Debug: log the raw state received from device
     this.emit('debug', `Received state: fmod=${productState.fmod}, auto=${productState.auto}, fnsp=${productState.fnsp}`);
 
-    const parsedState = this.codec.parseRawState(productState);
+    const parsedState = MessageCodec.parseRawState(productState);
 
     if (Object.keys(parsedState).length > 0) {
       this.updateState(parsedState);
     }
   }
 }
-
-// Export constants for use in other modules
-export { FAN_SPEED, HEATING_TEMP, HUMIDITY, PROTOCOL };

--- a/src/discovery/cloudApi.ts
+++ b/src/discovery/cloudApi.ts
@@ -244,6 +244,7 @@ export class DysonCloudApi {
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    timeoutId.unref();
 
     try {
       const response = await fetch(url, {

--- a/src/discovery/cloudApi.ts
+++ b/src/discovery/cloudApi.ts
@@ -425,9 +425,10 @@ export class DysonCloudApi {
   private async rateLimitDelay(): Promise<void> {
     const elapsed = Date.now() - this.lastRequestTime;
     if (elapsed < RATE_LIMIT_DELAY) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, RATE_LIMIT_DELAY - elapsed),
-      );
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, RATE_LIMIT_DELAY - elapsed);
+        timer.unref();
+      });
     }
   }
 }

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { DysonCloudApi } from './cloudApi.js';
-export { MdnsDiscovery } from './mdnsDiscovery.js';
+export { MdnsDiscovery, DEFAULT_DISCOVERY_TIMEOUT } from './mdnsDiscovery.js';
 export type {
   DiscoveredDevice,
   DiscoveryOptions,

--- a/src/discovery/mdnsDiscovery.ts
+++ b/src/discovery/mdnsDiscovery.ts
@@ -99,11 +99,12 @@ export class MdnsDiscovery {
         }
       });
 
-      // Set timeout to stop discovery
-      setTimeout(() => {
+      // Set timeout to stop discovery (unref to avoid keeping the process alive)
+      const discoveryTimeout = setTimeout(() => {
         this.cleanup();
         resolve(devices);
       }, timeout);
+      discoveryTimeout.unref();
     });
   }
 
@@ -142,11 +143,12 @@ export class MdnsDiscovery {
         }
       });
 
-      // Set timeout to stop discovery
-      setTimeout(() => {
+      // Set timeout to stop discovery (unref to avoid keeping the process alive)
+      const detailedTimeout = setTimeout(() => {
         this.cleanup();
         resolve(devices);
       }, timeout);
+      detailedTimeout.unref();
     });
   }
 

--- a/src/discovery/mdnsDiscovery.ts
+++ b/src/discovery/mdnsDiscovery.ts
@@ -79,6 +79,7 @@ export class MdnsDiscovery {
     const devices = new Map<string, string>();
 
     return new Promise((resolve) => {
+      let resolved = false;
       this.bonjour = this.bonjourFactory();
 
       // Service type is 'dyson_mqtt' (without leading underscore for bonjour-service)
@@ -86,25 +87,30 @@ export class MdnsDiscovery {
 
       this.browser = this.bonjour.find({ type: serviceType });
 
+      // Set timeout to stop discovery (unref to avoid keeping the process alive)
+      const discoveryTimeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          this.cleanup();
+          resolve(devices);
+        }
+      }, timeout);
+      discoveryTimeout.unref();
+
       this.browser.on('up', (service: Service) => {
         const device = this.parseService(service);
         if (device) {
           devices.set(device.serial, device.ipAddress);
 
           // Stop early if we found enough devices
-          if (maxDevices > 0 && devices.size >= maxDevices) {
+          if (maxDevices > 0 && devices.size >= maxDevices && !resolved) {
+            resolved = true;
+            clearTimeout(discoveryTimeout);
             this.cleanup();
             resolve(devices);
           }
         }
       });
-
-      // Set timeout to stop discovery (unref to avoid keeping the process alive)
-      const discoveryTimeout = setTimeout(() => {
-        this.cleanup();
-        resolve(devices);
-      }, timeout);
-      discoveryTimeout.unref();
     });
   }
 
@@ -121,11 +127,22 @@ export class MdnsDiscovery {
     const devices: DiscoveredDevice[] = [];
 
     return new Promise((resolve) => {
+      let resolved = false;
       this.bonjour = this.bonjourFactory();
 
       const serviceType = DYSON_MDNS_SERVICE.replace('_', '').replace('._tcp', '');
 
       this.browser = this.bonjour.find({ type: serviceType });
+
+      // Set timeout to stop discovery (unref to avoid keeping the process alive)
+      const detailedTimeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          this.cleanup();
+          resolve(devices);
+        }
+      }, timeout);
+      detailedTimeout.unref();
 
       this.browser.on('up', (service: Service) => {
         const device = this.parseService(service);
@@ -136,19 +153,14 @@ export class MdnsDiscovery {
           }
 
           // Stop early if we found enough devices
-          if (maxDevices > 0 && devices.length >= maxDevices) {
+          if (maxDevices > 0 && devices.length >= maxDevices && !resolved) {
+            resolved = true;
+            clearTimeout(detailedTimeout);
             this.cleanup();
             resolve(devices);
           }
         }
       });
-
-      // Set timeout to stop discovery (unref to avoid keeping the process alive)
-      const detailedTimeout = setTimeout(() => {
-        this.cleanup();
-        resolve(devices);
-      }, timeout);
-      detailedTimeout.unref();
     });
   }
 

--- a/src/discovery/mdnsDiscovery.ts
+++ b/src/discovery/mdnsDiscovery.ts
@@ -8,7 +8,7 @@ import { Bonjour, type Browser, type Service } from 'bonjour-service';
 import { DYSON_MDNS_SERVICE } from '../config/index.js';
 
 /** Default discovery timeout in milliseconds */
-const DEFAULT_TIMEOUT = 10000;
+export const DEFAULT_DISCOVERY_TIMEOUT = 10000;
 
 /** Minimum timeout allowed */
 const MIN_TIMEOUT = 1000;
@@ -73,7 +73,7 @@ export class MdnsDiscovery {
    * @returns Map of device serial numbers to IP addresses
    */
   async discover(options: DiscoveryOptions = {}): Promise<Map<string, string>> {
-    const timeout = this.validateTimeout(options.timeout ?? DEFAULT_TIMEOUT);
+    const timeout = this.validateTimeout(options.timeout ?? DEFAULT_DISCOVERY_TIMEOUT);
     const maxDevices = options.maxDevices ?? 0;
 
     const devices = new Map<string, string>();
@@ -114,7 +114,7 @@ export class MdnsDiscovery {
    * @returns Array of discovered device details
    */
   async discoverDetailed(options: DiscoveryOptions = {}): Promise<DiscoveredDevice[]> {
-    const timeout = this.validateTimeout(options.timeout ?? DEFAULT_TIMEOUT);
+    const timeout = this.validateTimeout(options.timeout ?? DEFAULT_DISCOVERY_TIMEOUT);
     const maxDevices = options.maxDevices ?? 0;
 
     const devices: DiscoveredDevice[] = [];

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -4,8 +4,6 @@ import { DysonPlatformAccessory } from './platformAccessory.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './config/index.js';
 import { MdnsDiscovery, DEFAULT_DISCOVERY_TIMEOUT } from './discovery/index.js';
 
-// This is only required when using Custom Services and Characteristics not support by HomeKit
-import { EveHomeKitTypes } from 'homebridge-lib/EveHomeKitTypes';
 
 /**
  * DysonPureCoolPlatform
@@ -23,12 +21,6 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
   // Track platform accessories for clean shutdown
   private readonly platformAccessories: DysonPlatformAccessory[] = [];
 
-  // This is only required when using Custom Services and Characteristics not support by HomeKit
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public readonly CustomServices: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public readonly CustomCharacteristics: any;
-
   constructor(
     public readonly log: Logging,
     public readonly config: PlatformConfig,
@@ -36,10 +28,6 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
   ) {
     this.Service = api.hap.Service;
     this.Characteristic = api.hap.Characteristic;
-
-    // This is only required when using Custom Services and Characteristics not support by HomeKit
-    this.CustomServices = new EveHomeKitTypes(this.api).Services;
-    this.CustomCharacteristics = new EveHomeKitTypes(this.api).Characteristics;
 
     this.log.debug('Finished initializing platform:', this.config.name);
 
@@ -107,6 +95,12 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
     }
     if (merged.isHeatingDisabled === undefined && this.config.enableHeater !== undefined) {
       merged.isHeatingDisabled = !this.config.enableHeater;
+    }
+    if (merged.isFilterStatusDisabled === undefined && this.config.enableFilterStatus !== undefined) {
+      merged.isFilterStatusDisabled = !this.config.enableFilterStatus;
+    }
+    if (merged.isHumidifierDisabled === undefined && this.config.enableHumidifier !== undefined) {
+      merged.isHumidifierDisabled = !this.config.enableHumidifier;
     }
 
     return merged;
@@ -224,6 +218,7 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
       if (!this.discoveredCacheUUIDs.includes(uuid)) {
         this.log.info('Removing accessory no longer in config:', accessory.displayName);
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+        this.accessories.delete(uuid);
       }
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -23,6 +23,9 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
   public readonly accessories: Map<string, PlatformAccessory> = new Map();
   public readonly discoveredCacheUUIDs: string[] = [];
 
+  // Track platform accessories for clean shutdown
+  private readonly platformAccessories: DysonPlatformAccessory[] = [];
+
   // This is only required when using Custom Services and Characteristics not support by HomeKit
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public readonly CustomServices: any;
@@ -52,6 +55,20 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
       // run the method to discover / register your devices as accessories
       await this.discoverDevices();
     });
+
+    // Cleanly disconnect all MQTT connections on shutdown
+    this.api.on('shutdown', async () => {
+      this.log.info('Shutting down, disconnecting devices...');
+      const disconnectPromises = this.platformAccessories.map(async (pa) => {
+        try {
+          await pa.disconnect();
+        } catch (error) {
+          this.log.debug('Error during shutdown disconnect:', error);
+        }
+      });
+      await Promise.allSettled(disconnectPromises);
+      this.log.info('All devices disconnected');
+    });
   }
 
   /**
@@ -63,6 +80,39 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
 
     // add the restored accessory to the accessories cache, so we can track if it has already been registered
     this.accessories.set(accessory.UUID, accessory);
+  }
+
+  /**
+   * Merge global config options with per-device options.
+   * Per-device settings take precedence over global settings.
+   * Returns a new object - does not mutate the original device config.
+   */
+  private mergeDeviceConfig(device: Record<string, unknown>): Record<string, unknown> {
+    const merged = { ...device };
+
+    if (merged.isNightModeEnabled === undefined && this.config.enableNightMode !== undefined) {
+      merged.isNightModeEnabled = this.config.enableNightMode;
+    }
+    if (merged.isJetFocusEnabled === undefined && this.config.enableJetFocus !== undefined) {
+      merged.isJetFocusEnabled = this.config.enableJetFocus;
+    }
+    if (merged.isContinuousMonitoringEnabled === undefined && this.config.enableContinuousMonitoring !== undefined) {
+      merged.isContinuousMonitoringEnabled = this.config.enableContinuousMonitoring;
+    }
+    if (merged.isTemperatureIgnored === undefined && this.config.enableTemperature !== undefined) {
+      merged.isTemperatureIgnored = !this.config.enableTemperature;
+    }
+    if (merged.isHumidityIgnored === undefined && this.config.enableHumidity !== undefined) {
+      merged.isHumidityIgnored = !this.config.enableHumidity;
+    }
+    if (merged.isAirQualityIgnored === undefined && this.config.enableAirQuality !== undefined) {
+      merged.isAirQualityIgnored = !this.config.enableAirQuality;
+    }
+    if (merged.isHeatingDisabled === undefined && this.config.enableHeater !== undefined) {
+      merged.isHeatingDisabled = !this.config.enableHeater;
+    }
+
+    return merged;
   }
 
   /**
@@ -104,41 +154,21 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
     }
 
     // loop over the configured devices and register each one if it has not already been registered
-    for (const device of devices) {
+    for (const rawDevice of devices) {
+      // Create merged config without mutating original
+      const device = this.mergeDeviceConfig(rawDevice);
+
       // Inject discovered IP address if not already configured
-      if (!device.ipAddress && discoveredIPs.has(device.serial)) {
-        device.ipAddress = discoveredIPs.get(device.serial);
+      if (!device.ipAddress && discoveredIPs.has(device.serial as string)) {
+        device.ipAddress = discoveredIPs.get(device.serial as string);
         this.log.info(`Using discovered IP ${device.ipAddress} for device ${device.serial}`);
       }
 
-      // Merge global options with per-device options (per-device takes precedence)
-      // Map global config names to per-device option names
-      if (device.isNightModeEnabled === undefined && this.config.enableNightMode !== undefined) {
-        device.isNightModeEnabled = this.config.enableNightMode;
-      }
-      if (device.isJetFocusEnabled === undefined && this.config.enableJetFocus !== undefined) {
-        device.isJetFocusEnabled = this.config.enableJetFocus;
-      }
-      if (device.isContinuousMonitoringEnabled === undefined && this.config.enableContinuousMonitoring !== undefined) {
-        device.isContinuousMonitoringEnabled = this.config.enableContinuousMonitoring;
-      }
-      if (device.isTemperatureIgnored === undefined && this.config.enableTemperature !== undefined) {
-        device.isTemperatureIgnored = !this.config.enableTemperature;
-      }
-      if (device.isHumidityIgnored === undefined && this.config.enableHumidity !== undefined) {
-        device.isHumidityIgnored = !this.config.enableHumidity;
-      }
-      if (device.isAirQualityIgnored === undefined && this.config.enableAirQuality !== undefined) {
-        device.isAirQualityIgnored = !this.config.enableAirQuality;
-      }
-      if (device.isHeatingDisabled === undefined && this.config.enableHeater !== undefined) {
-        device.isHeatingDisabled = !this.config.enableHeater;
-      }
       // generate a unique id for the accessory using the device serial number
-      const uuid = this.api.hap.uuid.generate(device.serial);
+      const uuid = this.api.hap.uuid.generate(device.serial as string);
 
       // determine display name (use configured name, or fall back to serial)
-      const displayName = device.name || `Dyson ${device.serial}`;
+      const displayName = (device.name as string) || `Dyson ${device.serial}`;
 
       // see if an accessory with the same uuid has already been registered and restored from
       // the cached devices we stored in the `configureAccessory` method above
@@ -165,7 +195,8 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
         this.api.updatePlatformAccessories([existingAccessory]);
 
         // create the accessory handler for the restored accessory
-        new DysonPlatformAccessory(this, existingAccessory);
+        const pa = new DysonPlatformAccessory(this, existingAccessory);
+        this.platformAccessories.push(pa);
       } else {
         // the accessory does not yet exist, so we need to create it
         this.log.info('Adding new accessory:', displayName);
@@ -183,7 +214,8 @@ export class DysonPureCoolPlatform implements DynamicPlatformPlugin {
         this.accessories.set(uuid, accessory);
 
         // create the accessory handler for the newly created accessory AFTER registration
-        new DysonPlatformAccessory(this, accessory);
+        const pa = new DysonPlatformAccessory(this, accessory);
+        this.platformAccessories.push(pa);
       }
 
       // push into discoveredCacheUUIDs

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,13 +2,10 @@ import type { API, Characteristic, DynamicPlatformPlugin, Logging, PlatformAcces
 
 import { DysonPlatformAccessory } from './platformAccessory.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './config/index.js';
-import { MdnsDiscovery } from './discovery/index.js';
+import { MdnsDiscovery, DEFAULT_DISCOVERY_TIMEOUT } from './discovery/index.js';
 
 // This is only required when using Custom Services and Characteristics not support by HomeKit
 import { EveHomeKitTypes } from 'homebridge-lib/EveHomeKitTypes';
-
-/** Default mDNS discovery timeout in milliseconds */
-const DEFAULT_DISCOVERY_TIMEOUT = 10000;
 
 /**
  * DysonPureCoolPlatform

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -52,14 +52,16 @@ interface DeviceConfig {
   heatingServiceType?: 'thermostat' | 'heater-cooler' | 'both';
   /** Enable full humidity range (0-100%) */
   fullRangeHumidity?: boolean;
-  /** Enable auto mode on device activation */
-  enableAutoModeWhenActivating?: boolean;
   /** Enable night mode switch */
   isNightModeEnabled?: boolean;
   /** Enable jet focus switch */
   isJetFocusEnabled?: boolean;
   /** Enable continuous monitoring switch */
   isContinuousMonitoringEnabled?: boolean;
+  /** Disable filter status service */
+  isFilterStatusDisabled?: boolean;
+  /** Disable humidifier control service */
+  isHumidifierDisabled?: boolean;
 }
 
 /**
@@ -154,6 +156,12 @@ export class DysonPlatformAccessory {
         options: this.extractDeviceOptions(config),
       });
 
+      // Apply polling interval from config if set
+      const pollingInterval = this.platform.config.pollingInterval as number | undefined;
+      if (pollingInterval) {
+        this.device.setPollingInterval(pollingInterval);
+      }
+
       // Connect to the device if IP address is available
       if (config.ipAddress) {
         this.connectDevice();
@@ -218,6 +226,9 @@ export class DysonPlatformAccessory {
             config.ipAddress = newIp;
             this.accessory.context.device = config;
 
+            // Clean up old accessory handler before recreating
+            this.accessoryHandler?.destroy();
+
             // Recreate the accessory handler with the new device
             this.accessoryHandler = new DysonLinkAccessory({
               accessory: this.accessory,
@@ -267,10 +278,11 @@ export class DysonPlatformAccessory {
       isHeatingDisabled: config.isHeatingDisabled,
       heatingServiceType: config.heatingServiceType,
       fullRangeHumidity: config.fullRangeHumidity,
-      enableAutoModeWhenActivating: config.enableAutoModeWhenActivating,
       isNightModeEnabled: config.isNightModeEnabled,
       isJetFocusEnabled: config.isJetFocusEnabled,
       isContinuousMonitoringEnabled: config.isContinuousMonitoringEnabled,
+      isFilterStatusDisabled: config.isFilterStatusDisabled,
+      isHumidifierDisabled: config.isHumidifierDisabled,
     };
   }
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -14,7 +14,7 @@ import { DysonLinkAccessory } from './accessories/dysonLinkAccessory.js';
 import type { DeviceOptions } from './accessories/dysonLinkAccessory.js';
 import type { DysonLinkDevice } from './devices/dysonLinkDevice.js';
 import { getDeviceModelName, isProductTypeSupported } from './config/index.js';
-import { MdnsDiscovery } from './discovery/index.js';
+import { MdnsDiscovery, DEFAULT_DISCOVERY_TIMEOUT } from './discovery/index.js';
 
 /**
  * Device configuration from plugin settings
@@ -167,7 +167,7 @@ export class DysonPlatformAccessory {
   }
 
   /** mDNS discovery timeout for IP refresh */
-  private static readonly MDNS_TIMEOUT = 10000;
+  private static readonly MDNS_TIMEOUT = DEFAULT_DISCOVERY_TIMEOUT;
 
   /**
    * Connect to the Dyson device

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -11,7 +11,18 @@ export type {
   MqttConnectFn,
 } from './mqttClient.js';
 
-export { MessageCodec, messageCodec } from './messageCodec.js';
+export { MessageCodec } from './messageCodec.js';
+export {
+  FAN_SPEED,
+  OSCILLATION_ANGLE,
+  TEMPERATURE,
+  HEATING_TEMP,
+  HUMIDITY,
+  FILTER,
+  FORMAT,
+  PROTOCOL,
+  PERCENT,
+} from './messageCodec.js';
 export type {
   CommandData,
   RawStateData,

--- a/src/protocol/messageCodec.ts
+++ b/src/protocol/messageCodec.ts
@@ -3,37 +3,53 @@
  *
  * Encodes commands and decodes state messages for Dyson devices.
  * Handles conversions between HomeKit values and Dyson protocol format.
+ * All methods are static - no instance state needed.
  */
 
 import type { DeviceState } from '../devices/types.js';
 
 // ============================================================================
-// Constants - No Magic Numbers
+// Constants - Exported for shared use across modules
 // ============================================================================
 
 /** Fan speed limits */
-const FAN_SPEED = {
+export const FAN_SPEED = {
   MIN: 1,
   MAX: 10,
+  DEFAULT: 4,
   AUTO: -1,
 } as const;
 
 /** Oscillation angle limits */
-const OSCILLATION_ANGLE = {
+export const OSCILLATION_ANGLE = {
   MIN: 45,
   MAX: 355,
 } as const;
 
 /** Temperature conversion constants */
-const TEMPERATURE = {
+export const TEMPERATURE = {
   /** Kelvin to Celsius offset */
   KELVIN_OFFSET: 273.15,
   /** Dyson uses Kelvin * 10 for precision */
   KELVIN_MULTIPLIER: 10,
 } as const;
 
+/** Heating temperature limits (Celsius) */
+export const HEATING_TEMP = {
+  MIN_CELSIUS: 1,
+  MAX_CELSIUS: 37,
+} as const;
+
+/** Humidity limits for humidifier */
+export const HUMIDITY = {
+  MIN_PERCENT: 0,
+  MAX_PERCENT: 100,
+  DEFAULT_MIN: 30,
+  DEFAULT_MAX: 70,
+} as const;
+
 /** Filter life constants */
-const FILTER = {
+export const FILTER = {
   /** Maximum filter life in hours */
   MAX_HOURS: 4300,
   /** Percentage divisor for conversion */
@@ -41,15 +57,24 @@ const FILTER = {
 } as const;
 
 /** Protocol string formatting */
-const FORMAT = {
+export const FORMAT = {
   /** Padding length for numeric values */
   PAD_LENGTH: 4,
   /** Padding character */
   PAD_CHAR: '0',
 } as const;
 
+/** Dyson protocol values */
+export const PROTOCOL = {
+  ON: 'ON',
+  OFF: 'OFF',
+  AUTO: 'AUTO',
+  FAN: 'FAN',
+  HEAT: 'HEAT',
+} as const;
+
 /** HomeKit percentage range */
-const PERCENT = {
+export const PERCENT = {
   MIN: 0,
   MAX: 100,
   /** Conversion factor for speed (10% per speed level) */
@@ -141,17 +166,15 @@ export interface DysonMessage {
 }
 
 /**
- * Message codec for encoding commands and decoding state
+ * Message codec for encoding commands and decoding state.
+ * All methods are static since the codec is stateless.
  */
 export class MessageCodec {
   /**
    * Extract value from raw state field
    * Handles both direct values ("ON") and change arrays (["OFF", "ON"])
-   *
-   * @param value - Raw value from state data
-   * @returns The actual string value (newest for arrays)
    */
-  private extractValue(value: string | [string, string] | undefined): string | undefined {
+  static extractValue(value: string | [string, string] | undefined): string | undefined {
     if (value === undefined) {
       return undefined;
     }
@@ -161,74 +184,63 @@ export class MessageCodec {
     }
     return value;
   }
+
   /**
    * Encode a command to send to the device
    *
    * @param data - Command data to encode
    * @returns JSON string to publish to command topic
    */
-  encodeCommand(data: Partial<CommandData>): string {
+  static encodeCommand(data: Partial<CommandData>): string {
     const encodedData: Record<string, string> = {};
 
-    // Fan power
     if (data.fanPower !== undefined) {
-      encodedData.fpwr = data.fanPower ? 'ON' : 'OFF';
+      encodedData.fpwr = data.fanPower ? PROTOCOL.ON : PROTOCOL.OFF;
     }
 
-    // Fan speed
     if (data.fanSpeed !== undefined) {
-      encodedData.fnsp = this.encodeFanSpeed(data.fanSpeed);
+      encodedData.fnsp = MessageCodec.encodeFanSpeed(data.fanSpeed);
     }
 
-    // Fan mode
     if (data.fanMode !== undefined) {
       encodedData.fmod = data.fanMode;
     }
 
-    // Oscillation
     if (data.oscillation !== undefined) {
-      encodedData.oson = data.oscillation ? 'ON' : 'OFF';
+      encodedData.oson = data.oscillation ? PROTOCOL.ON : PROTOCOL.OFF;
     }
 
-    // Oscillation angles
     if (data.oscillationAngleStart !== undefined) {
-      encodedData.oscs = this.encodeAngle(data.oscillationAngleStart);
+      encodedData.oscs = MessageCodec.encodeAngle(data.oscillationAngleStart);
     }
     if (data.oscillationAngleEnd !== undefined) {
-      encodedData.osce = this.encodeAngle(data.oscillationAngleEnd);
+      encodedData.osce = MessageCodec.encodeAngle(data.oscillationAngleEnd);
     }
 
-    // Night mode
     if (data.nightMode !== undefined) {
-      encodedData.nmod = data.nightMode ? 'ON' : 'OFF';
+      encodedData.nmod = data.nightMode ? PROTOCOL.ON : PROTOCOL.OFF;
     }
 
-    // Continuous monitoring
     if (data.continuousMonitoring !== undefined) {
-      encodedData.rhtm = data.continuousMonitoring ? 'ON' : 'OFF';
+      encodedData.rhtm = data.continuousMonitoring ? PROTOCOL.ON : PROTOCOL.OFF;
     }
 
-    // Front airflow / jet focus
     if (data.frontAirflow !== undefined) {
-      encodedData.ffoc = data.frontAirflow ? 'ON' : 'OFF';
+      encodedData.ffoc = data.frontAirflow ? PROTOCOL.ON : PROTOCOL.OFF;
     }
 
-    // Heating mode (HP models)
     if (data.heatingMode !== undefined) {
-      encodedData.hmod = data.heatingMode ? 'HEAT' : 'OFF';
+      encodedData.hmod = data.heatingMode ? PROTOCOL.HEAT : PROTOCOL.OFF;
     }
 
-    // Target temperature (HP models) - convert Celsius to Kelvin * 10
     if (data.targetTemperature !== undefined) {
-      encodedData.hmax = this.encodeTemperature(data.targetTemperature);
+      encodedData.hmax = MessageCodec.encodeTemperature(data.targetTemperature);
     }
 
-    // Humidifier mode (PH models)
     if (data.humidifierMode !== undefined) {
-      encodedData.hume = data.humidifierMode ? 'ON' : 'OFF';
+      encodedData.hume = data.humidifierMode ? PROTOCOL.ON : PROTOCOL.OFF;
     }
 
-    // Target humidity (PH models)
     if (data.targetHumidity !== undefined) {
       encodedData.humt = String(data.targetHumidity).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
     }
@@ -249,7 +261,7 @@ export class MessageCodec {
    * @param payload - Raw message payload (Buffer or object)
    * @returns Partial device state
    */
-  decodeState(payload: Buffer | DysonMessage): Partial<DeviceState> {
+  static decodeState(payload: Buffer | DysonMessage): Partial<DeviceState> {
     let message: DysonMessage;
 
     if (Buffer.isBuffer(payload)) {
@@ -262,156 +274,177 @@ export class MessageCodec {
       message = payload;
     }
 
-    // Get state data from either 'data' or 'product-state' field
     const rawState = message['product-state'] || message.data;
     if (!rawState) {
       return {};
     }
 
-    return this.parseRawState(rawState);
+    return MessageCodec.parseRawState(rawState);
   }
 
   /**
    * Parse raw state data into DeviceState
    * Handles both CURRENT-STATE (direct values) and STATE-CHANGE ([old, new] arrays)
    */
-  parseRawState(raw: RawStateData): Partial<DeviceState> {
+  static parseRawState(raw: RawStateData): Partial<DeviceState> {
     const state: Partial<DeviceState> = {};
 
     // Fan power
-    const fpwr = this.extractValue(raw.fpwr);
+    const fpwr = MessageCodec.extractValue(raw.fpwr);
     if (fpwr !== undefined) {
-      state.isOn = fpwr === 'ON';
+      state.isOn = fpwr === PROTOCOL.ON;
     }
 
     // Fan speed
-    // Note: fnsp only reports the current speed, NOT the mode.
-    // Even in auto mode, fnsp contains the actual speed (e.g., '0004'), not 'AUTO'.
-    // autoMode should only be determined by fmod or auto fields, not fnsp.
-    const fnsp = this.extractValue(raw.fnsp);
+    const fnsp = MessageCodec.extractValue(raw.fnsp);
     if (fnsp !== undefined) {
-      const { speed } = this.decodeFanSpeed(fnsp);
+      const { speed } = MessageCodec.decodeFanSpeed(fnsp);
       state.fanSpeed = speed;
     }
 
     // Fan mode (also indicates power and auto mode)
-    // fmod: 'OFF' = device off, 'FAN' = manual mode on, 'AUTO' = auto mode on
-    const fmod = this.extractValue(raw.fmod);
+    const fmod = MessageCodec.extractValue(raw.fmod);
     if (fmod !== undefined) {
-      if (fmod === 'OFF') {
+      if (fmod === PROTOCOL.OFF) {
         state.isOn = false;
         state.autoMode = false;
-      } else if (fmod === 'AUTO') {
+      } else if (fmod === PROTOCOL.AUTO) {
         state.isOn = true;
         state.autoMode = true;
-      } else if (fmod === 'FAN') {
+      } else if (fmod === PROTOCOL.FAN) {
         state.isOn = true;
         state.autoMode = false;
       }
     }
 
     // Auto mode field (some devices send this separately from fmod)
-    // auto: 'ON' = auto mode, 'OFF' = manual mode
-    const auto = this.extractValue(raw.auto);
+    const auto = MessageCodec.extractValue(raw.auto);
     if (auto !== undefined) {
-      state.autoMode = auto === 'ON';
+      state.autoMode = auto === PROTOCOL.ON;
     }
 
     // Oscillation
-    const oson = this.extractValue(raw.oson);
+    const oson = MessageCodec.extractValue(raw.oson);
     if (oson !== undefined) {
-      state.oscillation = oson === 'ON';
+      state.oscillation = oson === PROTOCOL.ON;
     }
 
     // Oscillation angles
-    const oscs = this.extractValue(raw.oscs);
+    const oscs = MessageCodec.extractValue(raw.oscs);
     if (oscs !== undefined) {
       state.oscillationAngleStart = parseInt(oscs, 10);
     }
-    const osce = this.extractValue(raw.osce);
+    const osce = MessageCodec.extractValue(raw.osce);
     if (osce !== undefined) {
       state.oscillationAngleEnd = parseInt(osce, 10);
     }
 
     // Night mode
-    const nmod = this.extractValue(raw.nmod);
+    const nmod = MessageCodec.extractValue(raw.nmod);
     if (nmod !== undefined) {
-      state.nightMode = nmod === 'ON';
+      state.nightMode = nmod === PROTOCOL.ON;
     }
 
     // Continuous monitoring
-    const rhtm = this.extractValue(raw.rhtm);
+    const rhtm = MessageCodec.extractValue(raw.rhtm);
     if (rhtm !== undefined) {
-      state.continuousMonitoring = rhtm === 'ON';
+      state.continuousMonitoring = rhtm === PROTOCOL.ON;
     }
 
     // Front airflow
-    const ffoc = this.extractValue(raw.ffoc);
+    const ffoc = MessageCodec.extractValue(raw.ffoc);
     if (ffoc !== undefined) {
-      state.frontAirflow = ffoc === 'ON';
+      state.frontAirflow = ffoc === PROTOCOL.ON;
     }
 
+    // Environmental sensor data
+    MessageCodec.parseEnvironmentalData(raw, state);
+
+    // Filter status
+    MessageCodec.parseFilterData(raw, state);
+
+    // Heating (HP models)
+    MessageCodec.parseHeatingData(raw, state);
+
+    // Humidifier (PH models)
+    MessageCodec.parseHumidifierData(raw, state);
+
+    // Link series specific fields
+    MessageCodec.parseLinkSeriesData(raw, state);
+
+    return state;
+  }
+
+  /**
+   * Parse environmental sensor data from raw state
+   */
+  static parseEnvironmentalData(raw: RawStateData, state: Partial<DeviceState>): void {
     // Temperature (Kelvin * 10)
-    const tact = this.extractValue(raw.tact);
-    if (tact !== undefined && tact !== 'OFF') {
-      state.temperature = parseInt(tact, 10);
+    const tact = MessageCodec.extractValue(raw.tact);
+    if (tact !== undefined && tact !== PROTOCOL.OFF) {
+      const value = parseInt(tact, 10);
+      if (!isNaN(value)) {
+        state.temperature = value;
+      }
     }
 
     // Humidity percentage
-    const hact = this.extractValue(raw.hact);
-    if (hact !== undefined && hact !== 'OFF') {
-      state.humidity = parseInt(hact, 10);
+    const hact = MessageCodec.extractValue(raw.hact);
+    if (hact !== undefined && hact !== PROTOCOL.OFF) {
+      const value = parseInt(hact, 10);
+      if (!isNaN(value)) {
+        state.humidity = value;
+      }
     }
 
-    // Air quality sensors - advanced models use p25r/p10r, basic use pact
-    const p25r = this.extractValue(raw.p25r);
-    if (p25r !== undefined && p25r !== 'INIT' && p25r !== 'OFF') {
+    // PM2.5 - newer models use p25r, older Link models use pact
+    const p25r = MessageCodec.extractValue(raw.p25r);
+    if (p25r !== undefined && p25r !== 'INIT' && p25r !== PROTOCOL.OFF) {
       const value = parseInt(p25r, 10);
       if (!isNaN(value)) {
         state.pm25 = value;
       }
     }
-    const p10r = this.extractValue(raw.p10r);
-    if (p10r !== undefined && p10r !== 'INIT' && p10r !== 'OFF') {
+    const p10r = MessageCodec.extractValue(raw.p10r);
+    if (p10r !== undefined && p10r !== 'INIT' && p10r !== PROTOCOL.OFF) {
       const value = parseInt(p10r, 10);
       if (!isNaN(value)) {
         state.pm10 = value;
       }
     }
-    // Basic sensors use pact for particulate index (not µg/m³)
-    const pact = this.extractValue(raw.pact);
-    if (pact !== undefined && pact !== 'INIT' && pact !== 'OFF') {
+    const pact = MessageCodec.extractValue(raw.pact);
+    if (pact !== undefined && pact !== 'INIT' && pact !== PROTOCOL.OFF) {
       const value = parseInt(pact, 10);
       if (!isNaN(value)) {
         state.pm25 = value;
       }
     }
     // VOC - va10 for advanced, vact for basic
-    const va10 = this.extractValue(raw.va10);
-    if (va10 !== undefined && va10 !== 'INIT' && va10 !== 'OFF') {
+    const va10 = MessageCodec.extractValue(raw.va10);
+    if (va10 !== undefined && va10 !== 'INIT' && va10 !== PROTOCOL.OFF) {
       const value = parseInt(va10, 10);
       if (!isNaN(value)) {
         state.vocIndex = value;
       }
     }
-    const vact = this.extractValue(raw.vact);
-    if (vact !== undefined && vact !== 'INIT' && vact !== 'OFF') {
+    const vact = MessageCodec.extractValue(raw.vact);
+    if (vact !== undefined && vact !== 'INIT' && vact !== PROTOCOL.OFF) {
       const value = parseInt(vact, 10);
       if (!isNaN(value)) {
         state.vocIndex = value;
       }
     }
     // NO2 index
-    const noxl = this.extractValue(raw.noxl);
-    if (noxl !== undefined && noxl !== 'INIT' && noxl !== 'OFF') {
+    const noxl = MessageCodec.extractValue(raw.noxl);
+    if (noxl !== undefined && noxl !== 'INIT' && noxl !== PROTOCOL.OFF) {
       const value = parseInt(noxl, 10);
       if (!isNaN(value)) {
         state.no2Index = value;
       }
     }
     // Formaldehyde (HCHO) level
-    const hchr = this.extractValue(raw.hchr);
-    if (hchr !== undefined && hchr !== 'INIT' && hchr !== 'OFF') {
+    const hchr = MessageCodec.extractValue(raw.hchr);
+    if (hchr !== undefined && hchr !== 'INIT' && hchr !== PROTOCOL.OFF) {
       const value = parseInt(hchr, 10);
       if (!isNaN(value)) {
         state.formaldehydeLevel = value;
@@ -419,9 +452,9 @@ export class MessageCodec {
     }
 
     // Sleep timer
-    const sltm = this.extractValue(raw.sltm);
+    const sltm = MessageCodec.extractValue(raw.sltm);
     if (sltm !== undefined) {
-      if (sltm === 'OFF') {
+      if (sltm === PROTOCOL.OFF) {
         state.sleepTimer = 0;
       } else {
         const value = parseInt(sltm, 10);
@@ -430,93 +463,95 @@ export class MessageCodec {
         }
       }
     }
+  }
 
-    // Filter status
-    const filf = this.extractValue(raw.filf);
+  /**
+   * Parse filter status from raw state
+   */
+  private static parseFilterData(raw: RawStateData, state: Partial<DeviceState>): void {
+    const filf = MessageCodec.extractValue(raw.filf);
     if (filf !== undefined) {
-      // HEPA filter life in hours
       state.hepaFilterLife = parseInt(filf, 10);
     }
-    const fltf = this.extractValue(raw.fltf);
+    const fltf = MessageCodec.extractValue(raw.fltf);
     if (fltf !== undefined) {
-      // HEPA filter percentage - convert to hours estimate
       const percent = parseInt(fltf, 10);
       state.hepaFilterLife = Math.round((percent / FILTER.PERCENT_DIVISOR) * FILTER.MAX_HOURS);
     }
-    const cflr = this.extractValue(raw.cflr);
+    const cflr = MessageCodec.extractValue(raw.cflr);
     if (cflr !== undefined) {
-      // Carbon filter percentage - convert to hours estimate
       const percent = parseInt(cflr, 10);
       state.carbonFilterLife = Math.round((percent / FILTER.PERCENT_DIVISOR) * FILTER.MAX_HOURS);
     }
+  }
 
-    // Heating (HP models)
-    const hmod = this.extractValue(raw.hmod);
+  /**
+   * Parse heating data from raw state (HP models)
+   */
+  private static parseHeatingData(raw: RawStateData, state: Partial<DeviceState>): void {
+    const hmod = MessageCodec.extractValue(raw.hmod);
     if (hmod !== undefined) {
-      state.heatingEnabled = hmod === 'HEAT';
+      state.heatingEnabled = hmod === PROTOCOL.HEAT;
     }
-    const hmax = this.extractValue(raw.hmax);
+    const hmax = MessageCodec.extractValue(raw.hmax);
     if (hmax !== undefined) {
       state.targetTemperature = parseInt(hmax, 10);
     }
-    // Heating status - whether heater is actively heating
-    const hsta = this.extractValue(raw.hsta);
+    const hsta = MessageCodec.extractValue(raw.hsta);
     if (hsta !== undefined) {
-      state.heatingActive = hsta === 'ON';
+      state.heatingActive = hsta === PROTOCOL.ON;
     }
+  }
 
-    // Humidifier (PH models)
-    const hume = this.extractValue(raw.hume);
+  /**
+   * Parse humidifier data from raw state (PH models)
+   */
+  private static parseHumidifierData(raw: RawStateData, state: Partial<DeviceState>): void {
+    const hume = MessageCodec.extractValue(raw.hume);
     if (hume !== undefined) {
-      state.humidifierEnabled = hume === 'ON' || hume === 'AUTO';
+      state.humidifierEnabled = hume === PROTOCOL.ON || hume === PROTOCOL.AUTO;
     }
-    const humt = this.extractValue(raw.humt);
+    const humt = MessageCodec.extractValue(raw.humt);
     if (humt !== undefined) {
       state.targetHumidity = parseInt(humt, 10);
     }
+  }
 
-    // Link series specific fields
-    // Fan state - whether fan is actively running (Link series uses this instead of fpwr)
-    const fnst = this.extractValue(raw.fnst);
+  /**
+   * Parse Link series specific fields
+   */
+  private static parseLinkSeriesData(raw: RawStateData, state: Partial<DeviceState>): void {
+    const fnst = MessageCodec.extractValue(raw.fnst);
     if (fnst !== undefined) {
-      state.fanState = fnst === 'ON';
+      state.fanState = fnst === PROTOCOL.ON;
     }
-    // Air quality target (1-4, for auto mode sensitivity)
-    const qtar = this.extractValue(raw.qtar);
+    const qtar = MessageCodec.extractValue(raw.qtar);
     if (qtar !== undefined) {
       const value = parseInt(qtar, 10);
       if (!isNaN(value)) {
         state.airQualityTarget = value;
       }
     }
-    // Error code
-    const ercd = this.extractValue(raw.ercd);
+    const ercd = MessageCodec.extractValue(raw.ercd);
     if (ercd !== undefined) {
       state.errorCode = ercd;
     }
-    // Warning code
-    const wacd = this.extractValue(raw.wacd);
+    const wacd = MessageCodec.extractValue(raw.wacd);
     if (wacd !== undefined) {
       state.warningCode = wacd;
     }
-    // Tilt status
-    const tilt = this.extractValue(raw.tilt);
+    const tilt = MessageCodec.extractValue(raw.tilt);
     if (tilt !== undefined) {
       state.tiltStatus = tilt;
     }
-
-    return state;
   }
 
   /**
    * Encode fan speed (1-10 or -1 for AUTO) to Dyson format
-   *
-   * @param speed - Fan speed (1-10) or -1 for AUTO
-   * @returns Encoded speed string (e.g., "0005" or "AUTO")
    */
-  encodeFanSpeed(speed: number): string {
+  static encodeFanSpeed(speed: number): string {
     if (speed < 0) {
-      return 'AUTO';
+      return PROTOCOL.AUTO;
     }
     const clampedSpeed = Math.max(FAN_SPEED.MIN, Math.min(FAN_SPEED.MAX, speed));
     return String(clampedSpeed).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
@@ -524,12 +559,9 @@ export class MessageCodec {
 
   /**
    * Decode fan speed from Dyson format
-   *
-   * @param encoded - Encoded speed (e.g., "0005" or "AUTO")
-   * @returns Object with speed (1-10 or -1 for AUTO) and autoMode flag
    */
-  decodeFanSpeed(encoded: string): { speed: number; autoMode: boolean } {
-    if (encoded === 'AUTO') {
+  static decodeFanSpeed(encoded: string): { speed: number; autoMode: boolean } {
+    if (encoded === PROTOCOL.AUTO) {
       return { speed: FAN_SPEED.AUTO, autoMode: true };
     }
     const speed = parseInt(encoded, 10);
@@ -538,11 +570,8 @@ export class MessageCodec {
 
   /**
    * Convert HomeKit percentage (0-100) to Dyson speed (1-10)
-   *
-   * @param percent - HomeKit percentage (0-100)
-   * @returns Dyson speed (1-10)
    */
-  percentToSpeed(percent: number): number {
+  static percentToSpeed(percent: number): number {
     if (percent <= PERCENT.MIN) {
       return FAN_SPEED.MIN;
     }
@@ -554,40 +583,26 @@ export class MessageCodec {
 
   /**
    * Convert Dyson speed (1-10) to HomeKit percentage (0-100)
-   *
-   * @param speed - Dyson speed (1-10) or -1 for AUTO
-   * @returns HomeKit percentage (0-100)
    */
-  speedToPercent(speed: number): number {
+  static speedToPercent(speed: number): number {
     if (speed < 0) {
-      // When fnsp is 'AUTO', we don't know the actual speed
-      // Return 0% to indicate the device is managing the speed
       return PERCENT.MIN;
     }
-    // Map 1-10 to 10-100% (in steps of 10)
-    // This correctly shows the actual speed even in auto mode,
-    // since devices report the real speed in fnsp when actively running
     return Math.max(PERCENT.MIN, Math.min(PERCENT.MAX, speed * PERCENT.PER_SPEED_LEVEL));
   }
 
   /**
    * Encode oscillation angle to Dyson format
-   *
-   * @param angle - Angle in degrees (45-355)
-   * @returns Encoded angle string (e.g., "0045")
    */
-  encodeAngle(angle: number): string {
+  static encodeAngle(angle: number): string {
     const clampedAngle = Math.max(OSCILLATION_ANGLE.MIN, Math.min(OSCILLATION_ANGLE.MAX, angle));
     return String(clampedAngle).padStart(FORMAT.PAD_LENGTH, FORMAT.PAD_CHAR);
   }
 
   /**
    * Encode temperature from Celsius to Dyson format (Kelvin * 10)
-   *
-   * @param celsius - Temperature in Celsius
-   * @returns Encoded temperature string (e.g., "2950" for 22°C)
    */
-  encodeTemperature(celsius: number): string {
+  static encodeTemperature(celsius: number): string {
     const kelvinTimes10 = Math.round(
       (celsius + TEMPERATURE.KELVIN_OFFSET) * TEMPERATURE.KELVIN_MULTIPLIER,
     );
@@ -596,27 +611,19 @@ export class MessageCodec {
 
   /**
    * Decode temperature from Dyson format to Celsius
-   *
-   * @param encoded - Encoded temperature (Kelvin * 10)
-   * @returns Temperature in Celsius
    */
-  decodeTemperature(encoded: string | number): number {
+  static decodeTemperature(encoded: string | number): number {
     const kelvinTimes10 = typeof encoded === 'string' ? parseInt(encoded, 10) : encoded;
     return (kelvinTimes10 / TEMPERATURE.KELVIN_MULTIPLIER) - TEMPERATURE.KELVIN_OFFSET;
   }
 
   /**
    * Create a REQUEST-CURRENT-STATE message
-   *
-   * @returns JSON string for requesting current state
    */
-  encodeRequestState(): string {
+  static encodeRequestState(): string {
     return JSON.stringify({
       msg: 'REQUEST-CURRENT-STATE',
       time: new Date().toISOString(),
     });
   }
 }
-
-// Export singleton instance for convenience
-export const messageCodec = new MessageCodec();

--- a/src/protocol/mqttClient.ts
+++ b/src/protocol/mqttClient.ts
@@ -113,6 +113,7 @@ export class DysonMqttClient extends EventEmitter {
   private reconnectAttempts = 0;
   private isReconnecting = false;
   private intentionalDisconnect = false;
+  private reconnectAbortController?: AbortController;
 
   constructor(options: MqttClientOptions, mqttConnect: MqttConnectFn = defaultMqttConnect) {
     super();
@@ -212,7 +213,9 @@ export class DysonMqttClient extends EventEmitter {
         this.connected = false;
         this.emit('close');
 
-        if (wasConnected && !this.intentionalDisconnect) {
+        // Only emit disconnect/offline and trigger reconnection once.
+        // Both 'close' and 'offline' events may fire; we use the first one.
+        if (wasConnected && !this.intentionalDisconnect && !this.isReconnecting) {
           this.emit('disconnect');
           this.emit('offline');
           this.handleReconnection();
@@ -227,7 +230,8 @@ export class DysonMqttClient extends EventEmitter {
         const wasConnected = this.connected;
         this.connected = false;
 
-        if (wasConnected && !this.intentionalDisconnect) {
+        // Only emit disconnect/offline if 'close' handler hasn't already handled it
+        if (wasConnected && !this.intentionalDisconnect && !this.isReconnecting) {
           this.emit('disconnect');
           this.emit('offline');
           this.handleReconnection();
@@ -248,6 +252,8 @@ export class DysonMqttClient extends EventEmitter {
 
     if (intentional) {
       this.intentionalDisconnect = true;
+      // Cancel any pending reconnection sleep
+      this.reconnectAbortController?.abort();
     }
 
     return new Promise((resolve) => {
@@ -455,10 +461,14 @@ export class DysonMqttClient extends EventEmitter {
 
     this.emit('reconnect', attempt + 1);
 
+    // Create abort controller to cancel reconnection on intentional disconnect
+    this.reconnectAbortController = new AbortController();
+    const { signal } = this.reconnectAbortController;
+
     // Schedule reconnection attempt
     sleep(delay).then(() => {
       // Abort if intentionally disconnected while waiting
-      if (this.intentionalDisconnect) {
+      if (this.intentionalDisconnect || signal.aborted) {
         this.isReconnecting = false;
         return;
       }
@@ -496,17 +506,29 @@ export class DysonMqttClient extends EventEmitter {
    */
   private async resubscribeToTopics(): Promise<void> {
     const topics = Array.from(this.subscribedTopics);
+    const errors: Error[] = [];
 
     for (const topic of topics) {
-      await new Promise<void>((resolve, reject) => {
-        this.client!.subscribe(topic, { qos: 0 }, (error) => {
-          if (error) {
-            reject(new Error(`Failed to resubscribe to ${topic}: ${error.message}`));
-          } else {
-            resolve();
-          }
+      try {
+        await new Promise<void>((resolve, reject) => {
+          this.client!.subscribe(topic, { qos: 0 }, (error) => {
+            if (error) {
+              reject(new Error(`Failed to resubscribe to ${topic}: ${error.message}`));
+            } else {
+              resolve();
+            }
+          });
         });
-      });
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+        // Continue resubscribing remaining topics
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error(
+        `Failed to resubscribe to ${errors.length} topic(s): ${errors.map((e) => e.message).join('; ')}`,
+      );
     }
   }
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -9,7 +9,10 @@
  * @returns Promise that resolves after the duration
  */
 export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+  });
 }
 
 /**

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared Test Utilities
+ *
+ * Common mock factories used across all test files.
+ * Eliminates duplication of mock creation code.
+ */
+
+import { jest } from '@jest/globals';
+import type { Logging, PlatformAccessory, Service } from 'homebridge';
+import type { DysonMqttClient } from '../../src/protocol/mqttClient.js';
+import type { DeviceInfo, MqttClientFactory } from '../../src/devices/index.js';
+
+// ============================================================================
+// Mock MQTT Client (for DysonMqttClient - used in device/service tests)
+// ============================================================================
+
+export type MockDysonMqttClient = jest.Mocked<DysonMqttClient> & {
+  _emit: (event: string, ...args: unknown[]) => void;
+};
+
+/**
+ * Create a mock DysonMqttClient with event handler support.
+ * Used in device and service tests.
+ */
+export function createMockMqttClient(): MockDysonMqttClient {
+  const eventHandlers: Map<string, ((...args: unknown[]) => void)[]> = new Map();
+
+  const mockClient = {
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!eventHandlers.has(event)) {
+        eventHandlers.set(event, []);
+      }
+      eventHandlers.get(event)!.push(handler);
+      return mockClient;
+    }),
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+    subscribeToStatus: jest.fn().mockResolvedValue(undefined),
+    requestCurrentState: jest.fn().mockResolvedValue(undefined),
+    publishCommand: jest.fn().mockResolvedValue(undefined),
+    isConnected: jest.fn().mockReturnValue(true),
+    _emit: (event: string, ...args: unknown[]) => {
+      const handlers = eventHandlers.get(event) || [];
+      handlers.forEach((handler) => handler(...args));
+    },
+  };
+
+  return mockClient as unknown as MockDysonMqttClient;
+}
+
+// ============================================================================
+// Mock raw MQTT client (for mqttClient.test.ts)
+// ============================================================================
+
+export type MockRawMqttClient = ReturnType<typeof createMockRawMqttClient>;
+
+/**
+ * Create a mock raw MQTT client (mqtt library level).
+ * Used in protocol-layer tests for DysonMqttClient.
+ */
+export function createMockRawMqttClient() {
+  const eventHandlers: Map<string, ((...args: unknown[]) => void)[]> = new Map();
+
+  const mockClient = {
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!eventHandlers.has(event)) {
+        eventHandlers.set(event, []);
+      }
+      eventHandlers.get(event)!.push(handler);
+      return mockClient;
+    }),
+    end: jest.fn((force: boolean, opts: object, callback: () => void) => {
+      callback();
+    }),
+    subscribe: jest.fn((topic: string, opts: object, callback: (error?: Error) => void) => {
+      callback();
+    }),
+    unsubscribe: jest.fn((topic: string, callback: (error?: Error) => void) => {
+      callback();
+    }),
+    publish: jest.fn((topic: string, payload: string, opts: object, callback: (error?: Error) => void) => {
+      callback();
+    }),
+    removeAllListeners: jest.fn(),
+    _emit: (event: string, ...args: unknown[]) => {
+      const handlers = eventHandlers.get(event) || [];
+      handlers.forEach((handler) => handler(...args));
+    },
+    _getHandlers: (event: string) => eventHandlers.get(event) || [],
+  };
+
+  return mockClient;
+}
+
+// ============================================================================
+// Mock HomeKit Service
+// ============================================================================
+
+/**
+ * Create a mock HomeKit Service with characteristic tracking.
+ */
+export function createMockService() {
+  const characteristics = new Map<string, {
+    onGet: jest.Mock;
+    onSet: jest.Mock;
+    setProps: jest.Mock;
+    getValue: jest.Mock;
+  }>();
+
+  const mockService = {
+    setCharacteristic: jest.fn().mockReturnThis(),
+    getCharacteristic: jest.fn((char: unknown) => {
+      const uuid = typeof char === 'object' && char !== null && 'UUID' in char
+        ? (char as { UUID: string }).UUID
+        : String(char);
+      if (!characteristics.has(uuid)) {
+        const charMock = {
+          onGet: jest.fn().mockReturnThis(),
+          onSet: jest.fn().mockReturnThis(),
+          setProps: jest.fn().mockReturnThis(),
+          getValue: jest.fn(),
+        };
+        characteristics.set(uuid, charMock);
+      }
+      return characteristics.get(uuid);
+    }),
+    updateCharacteristic: jest.fn(),
+    addOptionalCharacteristic: jest.fn().mockReturnThis(),
+    addLinkedService: jest.fn().mockReturnThis(),
+  };
+
+  return mockService as unknown as jest.Mocked<Service>;
+}
+
+// ============================================================================
+// Mock Logging
+// ============================================================================
+
+/**
+ * Create a mock Homebridge Logging instance.
+ */
+export function createMockLog(): jest.Mocked<Logging> {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+    success: jest.fn(),
+  } as unknown as jest.Mocked<Logging>;
+}
+
+// ============================================================================
+// Mock Accessory
+// ============================================================================
+
+/**
+ * Create a mock PlatformAccessory.
+ */
+export function createMockAccessory(primaryService?: jest.Mocked<Service>) {
+  return {
+    displayName: 'Test Dyson',
+    UUID: 'test-uuid',
+    getService: jest.fn((serviceType: unknown) => {
+      if (primaryService && serviceType === primaryService) {
+        return primaryService;
+      }
+      return undefined;
+    }),
+    addService: jest.fn(() => primaryService ?? createMockService()),
+    removeService: jest.fn(),
+    context: { device: {} },
+  } as unknown as jest.Mocked<PlatformAccessory>;
+}
+
+// ============================================================================
+// Test Device Defaults
+// ============================================================================
+
+/**
+ * Default device info for tests (TP04 model).
+ */
+export const DEFAULT_DEVICE_INFO: DeviceInfo = {
+  serial: 'ABC-AB-12345678',
+  productType: '438',
+  name: 'Living Room',
+  credentials: 'localPassword123',
+  ipAddress: '192.168.1.100',
+};
+
+/**
+ * Create a mock MQTT client factory that returns the given mock client.
+ */
+export function createMockMqttClientFactory(mockClient: MockDysonMqttClient): MqttClientFactory {
+  return jest.fn().mockReturnValue(mockClient) as unknown as MqttClientFactory;
+}

--- a/test/unit/accessories/dysonAccessory.test.ts
+++ b/test/unit/accessories/dysonAccessory.test.ts
@@ -194,7 +194,7 @@ describe('DysonAccessory', () => {
     it('should set model name based on product type', () => {
       expect(mockInfoService.setCharacteristic).toHaveBeenCalledWith(
         mockApi.hap.Characteristic.Model,
-        'Pure Cool Tower (TP04)',
+        'Dyson Pure Cool Tower (TP04)',
       );
     });
 
@@ -237,7 +237,7 @@ describe('DysonAccessory', () => {
 
       expect(newMockInfoService.setCharacteristic).toHaveBeenCalledWith(
         mockApi.hap.Characteristic.Model,
-        'Pure Hot+Cool Link (HP02)',
+        'Dyson Pure Hot+Cool Link (HP02)',
       );
     });
 
@@ -271,7 +271,7 @@ describe('DysonAccessory', () => {
 
       expect(newMockInfoService.setCharacteristic).toHaveBeenCalledWith(
         mockApi.hap.Characteristic.Model,
-        'Dyson (999)',
+        'Dyson Device (999)',
       );
     });
   });

--- a/test/unit/accessories/dysonLinkAccessory.test.ts
+++ b/test/unit/accessories/dysonLinkAccessory.test.ts
@@ -429,4 +429,149 @@ describe('DysonLinkAccessory', () => {
       );
     });
   });
+
+  describe('options propagation to setupServices', () => {
+    it('should disable temperature sensor when isTemperatureIgnored is true', () => {
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { isTemperatureIgnored: true },
+      });
+
+      // TP04 (438) normally has temperature sensor, but it should be disabled
+      expect(accessory.getTemperatureService()).toBeUndefined();
+    });
+
+    it('should disable humidity sensor when isHumidityIgnored is true', () => {
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { isHumidityIgnored: true },
+      });
+
+      expect(accessory.getHumidityService()).toBeUndefined();
+    });
+
+    it('should disable night mode when isNightModeEnabled is false', () => {
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { isNightModeEnabled: false },
+      });
+
+      expect(accessory.getNightModeService()).toBeUndefined();
+    });
+
+    it('should enable continuous monitoring when isContinuousMonitoringEnabled is true', () => {
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { isContinuousMonitoringEnabled: true },
+      });
+
+      expect(accessory.getContinuousMonitoringService()).toBeDefined();
+    });
+
+    it('should disable jet focus when isJetFocusEnabled is false', () => {
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { isJetFocusEnabled: false },
+      });
+
+      expect(accessory.getJetFocusService()).toBeUndefined();
+    });
+
+    it('should create heater-cooler service when heatingServiceType is heater-cooler', () => {
+      // Use HP04 (527) which supports heating
+      const hp04Device = new DysonLinkDevice(
+        { ...defaultDeviceInfo, productType: '527' },
+        mockMqttClientFactory,
+      );
+
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device: hp04Device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { heatingServiceType: 'heater-cooler' },
+      });
+
+      expect(accessory.getHeaterCoolerService()).toBeDefined();
+      expect(accessory.getThermostatService()).toBeUndefined();
+    });
+
+    it('should disable heating when isHeatingDisabled is true', () => {
+      const hp04Device = new DysonLinkDevice(
+        { ...defaultDeviceInfo, productType: '527' },
+        mockMqttClientFactory,
+      );
+
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device: hp04Device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { isHeatingDisabled: true },
+      });
+
+      expect(accessory.getThermostatService()).toBeUndefined();
+      expect(accessory.getHeaterCoolerService()).toBeUndefined();
+    });
+
+    it('should create both heating services when heatingServiceType is both', () => {
+      const hp04Device = new DysonLinkDevice(
+        { ...defaultDeviceInfo, productType: '527' },
+        mockMqttClientFactory,
+      );
+
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device: hp04Device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: { heatingServiceType: 'both' },
+      });
+
+      expect(accessory.getThermostatService()).toBeDefined();
+      expect(accessory.getHeaterCoolerService()).toBeDefined();
+    });
+
+    it('should pass options correctly when set before super() call', () => {
+      // This test verifies the fix for the constructor ordering bug.
+      // Previously, options were set AFTER super() which meant setupServices()
+      // would see an empty options object.
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: {
+          isTemperatureIgnored: true,
+          isHumidityIgnored: true,
+          isNightModeEnabled: false,
+          isJetFocusEnabled: false,
+        },
+      });
+
+      // All of these should be disabled because options were passed
+      expect(accessory.getTemperatureService()).toBeUndefined();
+      expect(accessory.getHumidityService()).toBeUndefined();
+      expect(accessory.getNightModeService()).toBeUndefined();
+      expect(accessory.getJetFocusService()).toBeUndefined();
+
+      // Fan service should always be present
+      expect(accessory.getFanService()).toBeDefined();
+    });
+  });
 });

--- a/test/unit/accessories/services/continuousMonitoringService.test.ts
+++ b/test/unit/accessories/services/continuousMonitoringService.test.ts
@@ -104,6 +104,16 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('ContinuousMonitoringService', () => {
   let continuousMonitoringService: ContinuousMonitoringService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -227,6 +237,7 @@ describe('ContinuousMonitoringService', () => {
 
     it('should call setContinuousMonitoring(true) when set to true', async () => {
       await onSetHandler(true);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -237,6 +248,7 @@ describe('ContinuousMonitoringService', () => {
 
     it('should call setContinuousMonitoring(false) when set to false', async () => {
       await onSetHandler(false);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -306,11 +318,16 @@ describe('ContinuousMonitoringService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setContinuousMonitoring fails', async () => {
+    it('should emit commandError when setContinuousMonitoring MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      await expect(onSetHandler(true)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
+      await onSetHandler(true);
+      await flushCommands();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/test/unit/accessories/services/fanService.test.ts
+++ b/test/unit/accessories/services/fanService.test.ts
@@ -108,6 +108,18 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ * Multiple await rounds are needed to process the full chain:
+ * queueMicrotask → flushCommand → sendCommand → publishCommand
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('FanService', () => {
   let fanService: FanService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -190,6 +202,7 @@ describe('FanService', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
@@ -267,6 +280,7 @@ describe('FanService', () => {
 
     it('should call setFanPower(true) when set to 1', async () => {
       await activeSetHandler(1);
+      await flushCommands();
 
       // setFanPower uses fmod command - FAN mode for manual, AUTO for auto mode
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -280,6 +294,7 @@ describe('FanService', () => {
 
     it('should call setFanPower(false) when set to 0', async () => {
       await activeSetHandler(0);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -307,16 +322,16 @@ describe('FanService', () => {
       expect(result).toBe(2);
     });
 
-    it('should return 1 (IDLE) when fan is on in auto mode', async () => {
-      // Simulate state change from device - fan on in auto mode
+    it('should return 2 (PURIFYING_AIR) when fan is on in auto mode', async () => {
+      // Simulate state change from device - fan on in auto mode with speed > 0
       mockMqttClient._emit('message', {
         topic: 'status',
         payload: Buffer.from('{}'),
-        data: { msg: 'STATE-CHANGE', 'product-state': { fpwr: 'ON', fmod: 'AUTO' } },
+        data: { msg: 'STATE-CHANGE', 'product-state': { fpwr: 'ON', fmod: 'AUTO', fnsp: '0004' } },
       });
 
       const result = currentStateGetHandler();
-      expect(result).toBe(1);
+      expect(result).toBe(2); // PURIFYING_AIR - device is on and actively purifying
     });
   });
 
@@ -340,6 +355,7 @@ describe('FanService', () => {
 
     it('should call setAutoMode(true) when set to 1 (AUTO)', async () => {
       await targetStateSetHandler(1);
+      await flushCommands();
 
       // Newer models use fmod only, no fpwr/auto fields
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -351,6 +367,7 @@ describe('FanService', () => {
 
     it('should call setAutoMode(false) when set to 0 (MANUAL)', async () => {
       await targetStateSetHandler(0);
+      await flushCommands();
 
       // Newer models use fmod and fnsp for manual mode
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -398,14 +415,14 @@ describe('FanService', () => {
       speedSetHandler(0);
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
-      await Promise.resolve(); // Allow async operations to complete
+      // Flush microtask command queue (Promise.resolve works with fake timers)
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
           data: { fmod: 'OFF' },
         }),
       );
-      jest.useRealTimers();
     });
 
     it('should call setFanSpeed with converted value', async () => {
@@ -413,14 +430,13 @@ describe('FanService', () => {
       speedSetHandler(50);
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
-      await Promise.resolve(); // Allow async operations to complete
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ fnsp: '0005' }),
         }),
       );
-      jest.useRealTimers();
     });
 
     it('should turn fan on if off when setting speed', async () => {
@@ -429,7 +445,7 @@ describe('FanService', () => {
       speedSetHandler(50);
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
-      await Promise.resolve(); // Allow async operations to complete
+      await flushCommands();
 
       // Should have both speed and power commands
       const calls = mockMqttClient.publishCommand.mock.calls;
@@ -437,7 +453,6 @@ describe('FanService', () => {
 
       // Check that we have a speed command
       expect(dataValues.some((d) => d.fnsp === '0005')).toBe(true);
-      jest.useRealTimers();
     });
   });
 
@@ -461,6 +476,7 @@ describe('FanService', () => {
 
     it('should call setOscillation(true) when set to 1', async () => {
       await swingModeSetHandler(1);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -471,6 +487,7 @@ describe('FanService', () => {
 
     it('should call setOscillation(false) when set to 0', async () => {
       await swingModeSetHandler(0);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -504,7 +521,7 @@ describe('FanService', () => {
       );
       expect(mockService.updateCharacteristic).toHaveBeenCalledWith(
         mockApi.hap.Characteristic.CurrentAirPurifierState,
-        1, // IDLE because auto mode
+        2, // PURIFYING_AIR - device is on and running
       );
       expect(mockService.updateCharacteristic).toHaveBeenCalledWith(
         mockApi.hap.Characteristic.TargetAirPurifierState,
@@ -593,41 +610,55 @@ describe('FanService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setFanPower(false) fails', async () => {
+    it('should emit commandError when setFanPower MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      // Test setFanPower(false) which has simpler async behavior without delays
-      await expect(activeSetHandler(0)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
+      await activeSetHandler(0);
+      await flushCommands();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
+      expect((errorHandler.mock.calls[0][0] as Error).message).toBe('MQTT error');
     });
 
-    it('should log error when setFanSpeed fails', async () => {
+    it('should emit commandError when setFanSpeed MQTT publish fails', async () => {
       jest.useFakeTimers();
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
       speedSetHandler(50);
-      // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
-      // Allow async operations to complete
-      await Promise.resolve();
-      await jest.runAllTimersAsync();
+      await flushCommands();
 
-      expect(mockLog.error).toHaveBeenCalled();
-      jest.useRealTimers();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('should throw and log error when setOscillation fails', async () => {
+    it('should emit commandError when setOscillation MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      await expect(swingModeSetHandler(1)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
+      await swingModeSetHandler(1);
+      await flushCommands();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('should throw and log error when setAutoMode fails', async () => {
+    it('should emit commandError when setAutoMode MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      await expect(targetStateSetHandler(1)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
+      await targetStateSetHandler(1);
+      await flushCommands();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/test/unit/accessories/services/fanService.test.ts
+++ b/test/unit/accessories/services/fanService.test.ts
@@ -610,17 +610,10 @@ describe('FanService', () => {
   });
 
   describe('error handling', () => {
-    it('should emit commandError when setFanPower MQTT publish fails', async () => {
+    it('should throw when setFanPower(false) MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      const errorHandler = jest.fn();
-      device.on('commandError', errorHandler);
-
-      await activeSetHandler(0);
-      await flushCommands();
-
-      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
-      expect((errorHandler.mock.calls[0][0] as Error).message).toBe('MQTT error');
+      await expect(activeSetHandler(0)).rejects.toThrow('MQTT error');
     });
 
     it('should emit commandError when setFanSpeed MQTT publish fails', async () => {

--- a/test/unit/accessories/services/heaterCoolerService.test.ts
+++ b/test/unit/accessories/services/heaterCoolerService.test.ts
@@ -110,6 +110,16 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('HeaterCoolerService', () => {
   let heaterCoolerService: HeaterCoolerService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -266,6 +276,7 @@ describe('HeaterCoolerService', () => {
 
     it('should enable heating when set to 1', async () => {
       await activeSetHandler(1);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -276,6 +287,7 @@ describe('HeaterCoolerService', () => {
 
     it('should disable heating when set to 0', async () => {
       await activeSetHandler(0);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -404,6 +416,7 @@ describe('HeaterCoolerService', () => {
 
     it('should set target temperature in Kelvin*10', async () => {
       await heatingThresholdSetHandler(22);
+      await flushCommands();
 
       // 22°C = 295.15 K = 2952 K*10
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -476,18 +489,22 @@ describe('HeaterCoolerService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setHeatingMode fails', async () => {
+    it('should emit commandError when setHeatingMode MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(activeSetHandler(1)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await activeSetHandler(1);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('should throw and log error when setTargetTemperature fails', async () => {
+    it('should emit commandError when setTargetTemperature MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(heatingThresholdSetHandler(22)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await heatingThresholdSetHandler(22);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/test/unit/accessories/services/humidifierControlService.test.ts
+++ b/test/unit/accessories/services/humidifierControlService.test.ts
@@ -120,6 +120,16 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('HumidifierControlService', () => {
   let humidifierService: HumidifierControlService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -311,6 +321,7 @@ describe('HumidifierControlService', () => {
 
     it('should call setHumidifier(true) when set to 1', async () => {
       await activeSetHandler(1);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -323,6 +334,7 @@ describe('HumidifierControlService', () => {
 
     it('should call setHumidifier(false) when set to 0', async () => {
       await activeSetHandler(0);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -371,6 +383,7 @@ describe('HumidifierControlService', () => {
 
     it('should call setHumidifierAuto() when set to HUMIDIFIER_OR_DEHUMIDIFIER (0)', async () => {
       await targetStateSetHandler(0);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -382,6 +395,7 @@ describe('HumidifierControlService', () => {
     it('should not send command when set to HUMIDIFIER (1)', async () => {
       mockMqttClient.publishCommand.mockClear();
       await targetStateSetHandler(1);
+      await flushCommands();
 
       // No command should be sent for manual mode
       expect(mockMqttClient.publishCommand).not.toHaveBeenCalled();
@@ -449,6 +463,7 @@ describe('HumidifierControlService', () => {
 
     it('should call setTargetHumidity when set', async () => {
       await targetHumiditySetHandler(55);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -606,25 +621,31 @@ describe('HumidifierControlService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setHumidifier fails', async () => {
+    it('should emit commandError when setHumidifier MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(activeSetHandler(1)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await activeSetHandler(1);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('should throw and log error when setTargetHumidity fails', async () => {
+    it('should emit commandError when setTargetHumidity MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(targetHumiditySetHandler(50)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await targetHumiditySetHandler(50);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('should throw and log error when setHumidifierAuto fails', async () => {
+    it('should emit commandError when setHumidifierAuto MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(targetStateSetHandler(0)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await targetStateSetHandler(0);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/test/unit/accessories/services/jetFocusService.test.ts
+++ b/test/unit/accessories/services/jetFocusService.test.ts
@@ -104,6 +104,16 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('JetFocusService', () => {
   let jetFocusService: JetFocusService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -242,6 +252,7 @@ describe('JetFocusService', () => {
 
     it('should call setJetFocus(true) when set to true', async () => {
       await onSetHandler(true);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -254,6 +265,7 @@ describe('JetFocusService', () => {
 
     it('should call setJetFocus(false) when set to false', async () => {
       await onSetHandler(false);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -332,11 +344,16 @@ describe('JetFocusService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setJetFocus fails', async () => {
+    it('should emit commandError when setJetFocus MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      await expect(onSetHandler(true)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
+      await onSetHandler(true);
+      await flushCommands();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/test/unit/accessories/services/nightModeService.test.ts
+++ b/test/unit/accessories/services/nightModeService.test.ts
@@ -104,6 +104,16 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('NightModeService', () => {
   let nightModeService: NightModeService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -214,6 +224,7 @@ describe('NightModeService', () => {
 
     it('should call setNightMode(true) when set to true', async () => {
       await onSetHandler(true);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -224,6 +235,7 @@ describe('NightModeService', () => {
 
     it('should call setNightMode(false) when set to false', async () => {
       await onSetHandler(false);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -293,11 +305,16 @@ describe('NightModeService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setNightMode fails', async () => {
+    it('should emit commandError when setNightMode MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
 
-      await expect(onSetHandler(true)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+
+      await onSetHandler(true);
+      await flushCommands();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/test/unit/accessories/services/thermostatService.test.ts
+++ b/test/unit/accessories/services/thermostatService.test.ts
@@ -124,6 +124,16 @@ function createMockApi() {
   } as unknown as API;
 }
 
+/**
+ * Flush microtask command queue.
+ * Commands are batched via queueMicrotask in DysonLinkDevice.
+ */
+async function flushCommands(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('ThermostatService', () => {
   let thermostatService: ThermostatService;
   let mockMqttClient: ReturnType<typeof createMockMqttClient>;
@@ -300,6 +310,7 @@ describe('ThermostatService', () => {
 
     it('should call setHeating(true) when set to HEAT (1)', async () => {
       await targetStateSetHandler(1);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -312,6 +323,7 @@ describe('ThermostatService', () => {
 
     it('should call setHeating(false) when set to OFF (0)', async () => {
       await targetStateSetHandler(0);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -402,6 +414,7 @@ describe('ThermostatService', () => {
 
     it('should call setTargetTemperature when set', async () => {
       await targetTempSetHandler(25);
+      await flushCommands();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -520,18 +533,22 @@ describe('ThermostatService', () => {
   });
 
   describe('error handling', () => {
-    it('should throw and log error when setHeating fails', async () => {
+    it('should emit commandError when setHeating MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(targetStateSetHandler(1)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await targetStateSetHandler(1);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('should throw and log error when setTargetTemperature fails', async () => {
+    it('should emit commandError when setTargetTemperature MQTT publish fails', async () => {
       mockMqttClient.publishCommand.mockRejectedValueOnce(new Error('MQTT error'));
-
-      await expect(targetTempSetHandler(25)).rejects.toThrow('MQTT error');
-      expect(mockLog.error).toHaveBeenCalled();
+      const errorHandler = jest.fn();
+      device.on('commandError', errorHandler);
+      await targetTempSetHandler(25);
+      await flushCommands();
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 

--- a/test/unit/config/deviceCatalog.test.ts
+++ b/test/unit/config/deviceCatalog.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Device Catalog Unit Tests
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  DEVICE_CATALOG,
+  getDeviceByProductType,
+  isProductTypeSupported,
+  getSupportedProductTypes,
+  getDeviceFeatures,
+  getDeviceModelName,
+  getProductTypeDisplayNames,
+  getDevicesBySeries,
+  getHeatingDevices,
+  getHumidifierDevices,
+} from '../../../src/config/deviceCatalog.js';
+import { DEFAULT_FEATURES } from '../../../src/devices/types.js';
+
+describe('Device Catalog', () => {
+  describe('DEVICE_CATALOG', () => {
+    it('should contain all expected device models', () => {
+      expect(DEVICE_CATALOG.length).toBeGreaterThanOrEqual(22);
+    });
+
+    it('should have unique product types', () => {
+      const productTypes = DEVICE_CATALOG.map(d => d.productType);
+      const uniqueTypes = new Set(productTypes);
+      expect(uniqueTypes.size).toBe(productTypes.length);
+    });
+
+    it('should have required fields for every device', () => {
+      for (const device of DEVICE_CATALOG) {
+        expect(device.productType).toBeTruthy();
+        expect(device.modelName).toBeTruthy();
+        expect(device.modelCode).toBeTruthy();
+        expect(device.series).toBeTruthy();
+        expect(device.features).toBeDefined();
+        expect(typeof device.formaldehyde).toBe('boolean');
+      }
+    });
+  });
+
+  describe('getDeviceByProductType', () => {
+    it('should return device for known product type', () => {
+      const device = getDeviceByProductType('438');
+      expect(device).toBeDefined();
+      expect(device!.modelCode).toBe('TP04');
+      expect(device!.series).toBe('pure-cool');
+    });
+
+    it('should return undefined for unknown product type', () => {
+      const device = getDeviceByProductType('999');
+      expect(device).toBeUndefined();
+    });
+  });
+
+  describe('isProductTypeSupported', () => {
+    it('should return true for supported types', () => {
+      expect(isProductTypeSupported('438')).toBe(true);
+      expect(isProductTypeSupported('455')).toBe(true);
+      expect(isProductTypeSupported('475')).toBe(true);
+    });
+
+    it('should return false for unsupported types', () => {
+      expect(isProductTypeSupported('000')).toBe(false);
+      expect(isProductTypeSupported('')).toBe(false);
+    });
+  });
+
+  describe('getSupportedProductTypes', () => {
+    it('should return all product type codes', () => {
+      const types = getSupportedProductTypes();
+      expect(types.length).toBe(DEVICE_CATALOG.length);
+      expect(types).toContain('438');
+      expect(types).toContain('455');
+    });
+  });
+
+  describe('getDeviceFeatures', () => {
+    it('should return correct features for TP04', () => {
+      const features = getDeviceFeatures('438');
+      expect(features.fan).toBe(true);
+      expect(features.oscillation).toBe(true);
+      expect(features.frontAirflow).toBe(true);
+      expect(features.heating).toBe(false);
+      expect(features.humidifier).toBe(false);
+    });
+
+    it('should return correct features for HP04 (heating)', () => {
+      const features = getDeviceFeatures('527');
+      expect(features.fan).toBe(true);
+      expect(features.heating).toBe(true);
+      expect(features.humidifier).toBe(false);
+    });
+
+    it('should return correct features for PH01 (humidifier)', () => {
+      const features = getDeviceFeatures('358');
+      expect(features.fan).toBe(true);
+      expect(features.heating).toBe(false);
+      expect(features.humidifier).toBe(true);
+    });
+
+    it('should return correct features for BP02 (Big+Quiet, no oscillation)', () => {
+      const features = getDeviceFeatures('664');
+      expect(features.fan).toBe(true);
+      expect(features.oscillation).toBe(false);
+      expect(features.no2Sensor).toBe(true);
+    });
+
+    it('should return correct features for Link series (basic sensors)', () => {
+      const features = getDeviceFeatures('475');
+      expect(features.basicAirQualitySensor).toBe(true);
+      expect(features.frontAirflow).toBe(false);
+    });
+
+    it('should return DEFAULT_FEATURES for unknown product type', () => {
+      const features = getDeviceFeatures('999');
+      expect(features).toEqual(DEFAULT_FEATURES);
+    });
+  });
+
+  describe('getDeviceModelName', () => {
+    it('should return model name for known device', () => {
+      const name = getDeviceModelName('438');
+      expect(name).toContain('TP04');
+      expect(name).toContain('Pure Cool');
+    });
+
+    it('should return fallback for unknown device', () => {
+      const name = getDeviceModelName('999');
+      expect(name).toContain('999');
+    });
+  });
+
+  describe('getProductTypeDisplayNames', () => {
+    it('should return mapping for all devices', () => {
+      const names = getProductTypeDisplayNames();
+      expect(Object.keys(names).length).toBe(DEVICE_CATALOG.length);
+      expect(names['438']).toBeDefined();
+    });
+  });
+
+  describe('getDevicesBySeries', () => {
+    it('should return Pure Cool Link devices', () => {
+      const devices = getDevicesBySeries('pure-cool-link');
+      expect(devices.length).toBeGreaterThan(0);
+      for (const device of devices) {
+        expect(device.series).toBe('pure-cool-link');
+      }
+    });
+
+    it('should return Big+Quiet devices', () => {
+      const devices = getDevicesBySeries('big-quiet');
+      expect(devices.length).toBeGreaterThan(0);
+      for (const device of devices) {
+        expect(device.series).toBe('big-quiet');
+      }
+    });
+  });
+
+  describe('getHeatingDevices', () => {
+    it('should return only devices with heating', () => {
+      const devices = getHeatingDevices();
+      expect(devices.length).toBeGreaterThan(0);
+      for (const device of devices) {
+        expect(device.features.heating).toBe(true);
+      }
+    });
+
+    it('should include HP series devices', () => {
+      const devices = getHeatingDevices();
+      const modelCodes = devices.map(d => d.modelCode);
+      expect(modelCodes).toContain('HP02');
+      expect(modelCodes).toContain('HP04');
+    });
+  });
+
+  describe('getHumidifierDevices', () => {
+    it('should return only devices with humidifier', () => {
+      const devices = getHumidifierDevices();
+      expect(devices.length).toBeGreaterThan(0);
+      for (const device of devices) {
+        expect(device.features.humidifier).toBe(true);
+      }
+    });
+
+    it('should include PH series devices', () => {
+      const devices = getHumidifierDevices();
+      const modelCodes = devices.map(d => d.modelCode);
+      expect(modelCodes).toContain('PH01');
+    });
+  });
+});

--- a/test/unit/devices/deviceFactory.test.ts
+++ b/test/unit/devices/deviceFactory.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Device Factory Unit Tests
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import { createDevice, isProductTypeSupported, getSupportedProductTypes } from '../../../src/devices/deviceFactory.js';
+import { DysonLinkDevice } from '../../../src/devices/dysonLinkDevice.js';
+import { createMockMqttClient, createMockMqttClientFactory, DEFAULT_DEVICE_INFO } from '../../helpers/mocks.js';
+
+describe('Device Factory', () => {
+  describe('createDevice', () => {
+    it('should create a DysonLinkDevice for supported product type', () => {
+      const mockClient = createMockMqttClient();
+      const factory = createMockMqttClientFactory(mockClient);
+
+      const device = createDevice(DEFAULT_DEVICE_INFO, factory);
+      expect(device).toBeInstanceOf(DysonLinkDevice);
+    });
+
+    it('should throw for unsupported product type', () => {
+      const mockClient = createMockMqttClient();
+      const factory = createMockMqttClientFactory(mockClient);
+
+      expect(() =>
+        createDevice(
+          { ...DEFAULT_DEVICE_INFO, productType: '999' },
+          factory,
+        ),
+      ).toThrow('Unsupported product type');
+    });
+
+    it('should create devices for all supported product types', () => {
+      const mockClient = createMockMqttClient();
+      const factory = createMockMqttClientFactory(mockClient);
+      const types = getSupportedProductTypes();
+
+      for (const productType of types) {
+        const device = createDevice(
+          { ...DEFAULT_DEVICE_INFO, productType },
+          factory,
+        );
+        expect(device).toBeInstanceOf(DysonLinkDevice);
+      }
+    });
+  });
+
+  describe('isProductTypeSupported', () => {
+    it('should return true for supported types', () => {
+      expect(isProductTypeSupported('438')).toBe(true);
+      expect(isProductTypeSupported('455')).toBe(true);
+      expect(isProductTypeSupported('527')).toBe(true);
+    });
+
+    it('should return false for unsupported types', () => {
+      expect(isProductTypeSupported('000')).toBe(false);
+    });
+  });
+
+  describe('getSupportedProductTypes', () => {
+    it('should return a non-empty array', () => {
+      const types = getSupportedProductTypes();
+      expect(types.length).toBeGreaterThan(0);
+    });
+
+    it('should include known product types', () => {
+      const types = getSupportedProductTypes();
+      expect(types).toContain('438');
+      expect(types).toContain('455');
+      expect(types).toContain('664');
+    });
+  });
+});

--- a/test/unit/devices/dysonLinkDevice.test.ts
+++ b/test/unit/devices/dysonLinkDevice.test.ts
@@ -9,6 +9,9 @@ import { createDevice, isProductTypeSupported, getSupportedProductTypes } from '
 import type { DeviceInfo, MqttClientFactory } from '../../../src/devices/index.js';
 import type { DysonMqttClient, MqttMessage } from '../../../src/protocol/mqttClient.js';
 
+/** Flush pending microtasks so queued commands are sent before assertions */
+const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
+
 // Create mock MQTT client
 function createMockMqttClient() {
   const eventHandlers: Map<string, ((...args: unknown[]) => void)[]> = new Map();
@@ -111,6 +114,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send ON command when turning on', async () => {
       await device.setFanPower(true);
+      await flushMicrotasks();
 
       // Newer models use fmod only (no auto field)
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -124,6 +128,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send OFF command when turning off', async () => {
       await device.setFanPower(false);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -140,6 +145,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send speed command for valid speed', async () => {
       await device.setFanSpeed(5);
+      await flushMicrotasks();
 
       // Newer models use fnsp and fmod only (no auto field)
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -151,6 +157,7 @@ describe('DysonLinkDevice', () => {
 
     it('should clamp speed to minimum 1', async () => {
       await device.setFanSpeed(0);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -161,6 +168,7 @@ describe('DysonLinkDevice', () => {
 
     it('should clamp speed to maximum 10', async () => {
       await device.setFanSpeed(15);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -171,6 +179,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send AUTO command for negative speed', async () => {
       await device.setFanSpeed(-1);
+      await flushMicrotasks();
 
       // Newer models use fmod only (no auto field)
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -188,6 +197,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send ON command when enabling', async () => {
       await device.setOscillation(true);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -198,6 +208,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send OFF command when disabling', async () => {
       await device.setOscillation(false);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -214,6 +225,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send ON command when enabling', async () => {
       await device.setNightMode(true);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -224,6 +236,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send OFF command when disabling', async () => {
       await device.setNightMode(false);
+      await flushMicrotasks();
 
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -240,6 +253,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send AUTO command when enabling', async () => {
       await device.setAutoMode(true);
+      await flushMicrotasks();
 
       // Newer models use fmod only (no fpwr/auto fields)
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
@@ -251,6 +265,7 @@ describe('DysonLinkDevice', () => {
 
     it('should send FAN command with speed when disabling', async () => {
       await device.setAutoMode(false);
+      await flushMicrotasks();
 
       // Newer models use fmod and fnsp for manual mode
       expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(

--- a/test/unit/protocol/messageCodec.test.ts
+++ b/test/unit/protocol/messageCodec.test.ts
@@ -2,21 +2,15 @@
  * MessageCodec Unit Tests
  */
 
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 
-import { MessageCodec, messageCodec } from '../../../src/protocol/messageCodec.js';
+import { MessageCodec } from '../../../src/protocol/messageCodec.js';
 import type { DysonMessage } from '../../../src/protocol/messageCodec.js';
 
 describe('MessageCodec', () => {
-  let codec: MessageCodec;
-
-  beforeEach(() => {
-    codec = new MessageCodec();
-  });
-
   describe('encodeCommand', () => {
     it('should encode fan power command', () => {
-      const result = JSON.parse(codec.encodeCommand({ fanPower: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanPower: true }));
 
       expect(result.msg).toBe('STATE-SET');
       expect(result['mode-reason']).toBe('LAPP');
@@ -25,42 +19,42 @@ describe('MessageCodec', () => {
     });
 
     it('should encode fan power off', () => {
-      const result = JSON.parse(codec.encodeCommand({ fanPower: false }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanPower: false }));
       expect(result.data.fpwr).toBe('OFF');
     });
 
     it('should encode fan speed', () => {
-      const result = JSON.parse(codec.encodeCommand({ fanSpeed: 5 }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanSpeed: 5 }));
       expect(result.data.fnsp).toBe('0005');
     });
 
     it('should encode fan speed 10', () => {
-      const result = JSON.parse(codec.encodeCommand({ fanSpeed: 10 }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanSpeed: 10 }));
       expect(result.data.fnsp).toBe('0010');
     });
 
     it('should encode auto fan speed', () => {
-      const result = JSON.parse(codec.encodeCommand({ fanSpeed: -1 }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanSpeed: -1 }));
       expect(result.data.fnsp).toBe('AUTO');
     });
 
     it('should encode fan mode', () => {
-      const result = JSON.parse(codec.encodeCommand({ fanMode: 'AUTO' }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanMode: 'AUTO' }));
       expect(result.data.fmod).toBe('AUTO');
     });
 
     it('should encode oscillation on', () => {
-      const result = JSON.parse(codec.encodeCommand({ oscillation: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ oscillation: true }));
       expect(result.data.oson).toBe('ON');
     });
 
     it('should encode oscillation off', () => {
-      const result = JSON.parse(codec.encodeCommand({ oscillation: false }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ oscillation: false }));
       expect(result.data.oson).toBe('OFF');
     });
 
     it('should encode oscillation angles', () => {
-      const result = JSON.parse(codec.encodeCommand({
+      const result = JSON.parse(MessageCodec.encodeCommand({
         oscillationAngleStart: 45,
         oscillationAngleEnd: 180,
       }));
@@ -69,43 +63,43 @@ describe('MessageCodec', () => {
     });
 
     it('should encode night mode', () => {
-      const result = JSON.parse(codec.encodeCommand({ nightMode: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ nightMode: true }));
       expect(result.data.nmod).toBe('ON');
     });
 
     it('should encode continuous monitoring', () => {
-      const result = JSON.parse(codec.encodeCommand({ continuousMonitoring: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ continuousMonitoring: true }));
       expect(result.data.rhtm).toBe('ON');
     });
 
     it('should encode front airflow', () => {
-      const result = JSON.parse(codec.encodeCommand({ frontAirflow: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ frontAirflow: true }));
       expect(result.data.ffoc).toBe('ON');
     });
 
     it('should encode heating mode', () => {
-      const result = JSON.parse(codec.encodeCommand({ heatingMode: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ heatingMode: true }));
       expect(result.data.hmod).toBe('HEAT');
     });
 
     it('should encode target temperature', () => {
-      const result = JSON.parse(codec.encodeCommand({ targetTemperature: 22 }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ targetTemperature: 22 }));
       // 22°C = 295.15K * 10 = 2952 (rounded)
       expect(result.data.hmax).toBe('2952');
     });
 
     it('should encode humidifier mode', () => {
-      const result = JSON.parse(codec.encodeCommand({ humidifierMode: true }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ humidifierMode: true }));
       expect(result.data.hume).toBe('ON');
     });
 
     it('should encode target humidity', () => {
-      const result = JSON.parse(codec.encodeCommand({ targetHumidity: 50 }));
+      const result = JSON.parse(MessageCodec.encodeCommand({ targetHumidity: 50 }));
       expect(result.data.humt).toBe('0050');
     });
 
     it('should encode multiple commands at once', () => {
-      const result = JSON.parse(codec.encodeCommand({
+      const result = JSON.parse(MessageCodec.encodeCommand({
         fanPower: true,
         fanSpeed: 7,
         oscillation: true,
@@ -131,7 +125,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(Buffer.from(JSON.stringify(message)));
+      const state = MessageCodec.decodeState(Buffer.from(JSON.stringify(message)));
 
       expect(state.isOn).toBe(true);
       expect(state.fanSpeed).toBe(5);
@@ -149,7 +143,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.isOn).toBe(true); // fmod: 'AUTO' sets isOn: true
       expect(state.fanSpeed).toBe(-1);
@@ -165,7 +159,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.isOn).toBe(true);
       expect(state.fanSpeed).toBe(3);
@@ -180,7 +174,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.oscillationAngleStart).toBe(45);
       expect(state.oscillationAngleEnd).toBe(270);
@@ -194,7 +188,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.temperature).toBe(2950);
     });
@@ -207,7 +201,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.temperature).toBeUndefined();
     });
@@ -220,7 +214,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.humidity).toBe(45);
     });
@@ -236,7 +230,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.pm25).toBe(12);
       expect(state.pm10).toBe(8);
@@ -253,7 +247,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.hepaFilterLife).toBe(2500);
       expect(state.carbonFilterLife).toBe(3440); // 80% of 4300
@@ -267,7 +261,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.hepaFilterLife).toBe(2150); // 50% of 4300
     });
@@ -281,7 +275,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.heatingEnabled).toBe(true);
       expect(state.targetTemperature).toBe(2950);
@@ -296,7 +290,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.humidifierEnabled).toBe(true);
       expect(state.targetHumidity).toBe(55);
@@ -310,7 +304,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.autoMode).toBe(true);
     });
@@ -323,7 +317,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.isOn).toBe(false);
     });
@@ -336,13 +330,13 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
 
       expect(state.frontAirflow).toBe(true);
     });
 
     it('should return empty object for invalid buffer', () => {
-      const state = codec.decodeState(Buffer.from('not valid json'));
+      const state = MessageCodec.decodeState(Buffer.from('not valid json'));
       expect(state).toEqual({});
     });
 
@@ -350,7 +344,7 @@ describe('MessageCodec', () => {
       const message: DysonMessage = {
         msg: 'UNKNOWN',
       };
-      const state = codec.decodeState(message);
+      const state = MessageCodec.decodeState(message);
       expect(state).toEqual({});
     });
 
@@ -365,7 +359,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message as DysonMessage);
+      const state = MessageCodec.decodeState(message as DysonMessage);
 
       expect(state.isOn).toBe(true);
       expect(state.fanSpeed).toBe(7);
@@ -383,7 +377,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message as DysonMessage);
+      const state = MessageCodec.decodeState(message as DysonMessage);
 
       expect(state.autoMode).toBe(true);
       expect(state.nightMode).toBe(true);
@@ -400,7 +394,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message as DysonMessage);
+      const state = MessageCodec.decodeState(message as DysonMessage);
 
       expect(state.temperature).toBe(2950);
       expect(state.humidity).toBe(55);
@@ -417,7 +411,7 @@ describe('MessageCodec', () => {
         },
       };
 
-      const state = codec.decodeState(message as DysonMessage);
+      const state = MessageCodec.decodeState(message as DysonMessage);
 
       expect(state.heatingEnabled).toBe(true);
       expect(state.targetTemperature).toBe(2950);
@@ -428,41 +422,41 @@ describe('MessageCodec', () => {
 
   describe('encodeFanSpeed', () => {
     it('should encode speed 1 as 0001', () => {
-      expect(codec.encodeFanSpeed(1)).toBe('0001');
+      expect(MessageCodec.encodeFanSpeed(1)).toBe('0001');
     });
 
     it('should encode speed 10 as 0010', () => {
-      expect(codec.encodeFanSpeed(10)).toBe('0010');
+      expect(MessageCodec.encodeFanSpeed(10)).toBe('0010');
     });
 
     it('should encode negative speed as AUTO', () => {
-      expect(codec.encodeFanSpeed(-1)).toBe('AUTO');
+      expect(MessageCodec.encodeFanSpeed(-1)).toBe('AUTO');
     });
 
     it('should clamp speed below 1 to 1', () => {
-      expect(codec.encodeFanSpeed(0)).toBe('0001');
+      expect(MessageCodec.encodeFanSpeed(0)).toBe('0001');
     });
 
     it('should clamp speed above 10 to 10', () => {
-      expect(codec.encodeFanSpeed(15)).toBe('0010');
+      expect(MessageCodec.encodeFanSpeed(15)).toBe('0010');
     });
   });
 
   describe('decodeFanSpeed', () => {
     it('should decode 0005 to speed 5', () => {
-      const result = codec.decodeFanSpeed('0005');
+      const result = MessageCodec.decodeFanSpeed('0005');
       expect(result.speed).toBe(5);
       expect(result.autoMode).toBe(false);
     });
 
     it('should decode AUTO', () => {
-      const result = codec.decodeFanSpeed('AUTO');
+      const result = MessageCodec.decodeFanSpeed('AUTO');
       expect(result.speed).toBe(-1);
       expect(result.autoMode).toBe(true);
     });
 
     it('should handle invalid input', () => {
-      const result = codec.decodeFanSpeed('invalid');
+      const result = MessageCodec.decodeFanSpeed('invalid');
       expect(result.speed).toBe(0);
       expect(result.autoMode).toBe(false);
     });
@@ -470,107 +464,103 @@ describe('MessageCodec', () => {
 
   describe('percentToSpeed', () => {
     it('should convert 0% to speed 1', () => {
-      expect(codec.percentToSpeed(0)).toBe(1);
+      expect(MessageCodec.percentToSpeed(0)).toBe(1);
     });
 
     it('should convert 10% to speed 1', () => {
-      expect(codec.percentToSpeed(10)).toBe(1);
+      expect(MessageCodec.percentToSpeed(10)).toBe(1);
     });
 
     it('should convert 11% to speed 2', () => {
-      expect(codec.percentToSpeed(11)).toBe(2);
+      expect(MessageCodec.percentToSpeed(11)).toBe(2);
     });
 
     it('should convert 50% to speed 5', () => {
-      expect(codec.percentToSpeed(50)).toBe(5);
+      expect(MessageCodec.percentToSpeed(50)).toBe(5);
     });
 
     it('should convert 100% to speed 10', () => {
-      expect(codec.percentToSpeed(100)).toBe(10);
+      expect(MessageCodec.percentToSpeed(100)).toBe(10);
     });
 
     it('should handle negative values', () => {
-      expect(codec.percentToSpeed(-10)).toBe(1);
+      expect(MessageCodec.percentToSpeed(-10)).toBe(1);
     });
   });
 
   describe('speedToPercent', () => {
     it('should convert speed 1 to 10%', () => {
-      expect(codec.speedToPercent(1)).toBe(10);
+      expect(MessageCodec.speedToPercent(1)).toBe(10);
     });
 
     it('should convert speed 5 to 50%', () => {
-      expect(codec.speedToPercent(5)).toBe(50);
+      expect(MessageCodec.speedToPercent(5)).toBe(50);
     });
 
     it('should convert speed 10 to 100%', () => {
-      expect(codec.speedToPercent(10)).toBe(100);
+      expect(MessageCodec.speedToPercent(10)).toBe(100);
     });
 
     it('should convert AUTO (-1) to 0%', () => {
       // When fnsp is 'AUTO', we don't know the actual speed
       // so we show 0% to indicate the device is managing the speed
-      expect(codec.speedToPercent(-1)).toBe(0);
+      expect(MessageCodec.speedToPercent(-1)).toBe(0);
     });
 
     it('should handle 0 speed', () => {
-      expect(codec.speedToPercent(0)).toBe(0);
+      expect(MessageCodec.speedToPercent(0)).toBe(0);
     });
   });
 
   describe('encodeAngle', () => {
     it('should encode angle with padding', () => {
-      expect(codec.encodeAngle(45)).toBe('0045');
-      expect(codec.encodeAngle(180)).toBe('0180');
-      expect(codec.encodeAngle(355)).toBe('0355');
+      expect(MessageCodec.encodeAngle(45)).toBe('0045');
+      expect(MessageCodec.encodeAngle(180)).toBe('0180');
+      expect(MessageCodec.encodeAngle(355)).toBe('0355');
     });
 
     it('should clamp angle below 45', () => {
-      expect(codec.encodeAngle(30)).toBe('0045');
+      expect(MessageCodec.encodeAngle(30)).toBe('0045');
     });
 
     it('should clamp angle above 355', () => {
-      expect(codec.encodeAngle(400)).toBe('0355');
+      expect(MessageCodec.encodeAngle(400)).toBe('0355');
     });
   });
 
   describe('temperature conversion', () => {
     it('should encode 20°C correctly', () => {
       // 20°C = 293.15K * 10 = 2932 (rounded)
-      expect(codec.encodeTemperature(20)).toBe('2932');
+      expect(MessageCodec.encodeTemperature(20)).toBe('2932');
     });
 
     it('should encode 0°C correctly', () => {
       // 0°C = 273.15K * 10 = 2732 (rounded)
-      expect(codec.encodeTemperature(0)).toBe('2732');
+      expect(MessageCodec.encodeTemperature(0)).toBe('2732');
     });
 
     it('should decode temperature to Celsius', () => {
       // 2950 / 10 - 273.15 = 21.85°C
-      expect(codec.decodeTemperature(2950)).toBeCloseTo(21.85, 2);
+      expect(MessageCodec.decodeTemperature(2950)).toBeCloseTo(21.85, 2);
     });
 
     it('should decode string temperature', () => {
-      expect(codec.decodeTemperature('2950')).toBeCloseTo(21.85, 2);
+      expect(MessageCodec.decodeTemperature('2950')).toBeCloseTo(21.85, 2);
     });
   });
 
   describe('encodeRequestState', () => {
     it('should create valid request message', () => {
-      const result = JSON.parse(codec.encodeRequestState());
+      const result = JSON.parse(MessageCodec.encodeRequestState());
 
       expect(result.msg).toBe('REQUEST-CURRENT-STATE');
       expect(result.time).toBeDefined();
     });
   });
 
-  describe('singleton instance', () => {
-    it('should export a singleton instance', () => {
-      expect(messageCodec).toBeInstanceOf(MessageCodec);
-    });
-
-    it('should work correctly', () => {
-      const result = JSON.parse(messageCodec.encodeCommand({ fanPower: true }));
+  describe('static methods', () => {
+    it('should work correctly as static calls', () => {
+      const result = JSON.parse(MessageCodec.encodeCommand({ fanPower: true }));
       expect(result.data.fpwr).toBe('ON');
     });
   });


### PR DESCRIPTION
Security:
- Replace execSync/curl with native fetch() in UI server
- Remove credential logging from Homebridge UI server

Bug fixes:
- Fix FanService auto-mode IDLE vs PURIFYING_AIR state (device is
  actively purifying when on in auto mode, not idle)

Architecture:
- Make MessageCodec methods static and export shared constants
  (FAN_SPEED, TEMPERATURE, PROTOCOL, etc.) eliminating duplication
- Replace setTimeout power-on hack with queueMicrotask command queue
  in DysonLinkDevice, allowing concurrent HomeKit updates to be
  merged into a single MQTT command
- Consolidate duplicated environmental sensor parsing from
  dysonDevice into MessageCodec.parseEnvironmentalData
- Add platform shutdown handler for clean MQTT disconnection
- Stop mutating config objects in platform.ts - use immutable copies
- Add error handling in flushCommand to prevent unhandled rejections

Testing:
- Extract shared test utilities into test/helpers/mocks.ts
- Add tests for deviceCatalog and deviceFactory
- Fix all service tests for microtask-based command queue
- Update error handling tests to verify commandError events

All 556 tests pass, lint clean.