### PR TITLE
feat: add PH05 (Purifier Humidify+Cool De-Nox) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | **Pure Hot+Cool Formaldehyde** | HP09 | Fan, Heating, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Humidify+Cool** | PH01, PH02, PH03 | Fan, Humidifier, Air Quality, Temp, Humidity, Jet Focus |
 | **Purifier Humidify+Cool Formaldehyde** | PH04 | Fan, Humidifier, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
+| **Purifier Humidify+Cool De-Nox** | PH05 | Fan, Humidifier, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Big+Quiet** | BP02, BP03, BP04, BP06 | Fan, Air Quality (incl. NO2), Temp, Humidity |
 
 ## Installation

--- a/src/config/deviceCatalog.ts
+++ b/src/config/deviceCatalog.ts
@@ -16,7 +16,7 @@ export type DeviceSeries =
   | 'pure-cool'           // TP04, TP07, TP09, TP11, DP04
   | 'hot-cool-link'       // HP02 (older Link series)
   | 'hot-cool'            // HP04, HP06, HP07, HP09, HP11
-  | 'humidify-cool'       // PH01, PH02, PH03, PH04
+  | 'humidify-cool'       // PH01, PH02, PH03, PH04, PH05
   | 'big-quiet';          // BP02, BP03, BP04, BP06
 
 /**
@@ -239,15 +239,7 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
   {
     productType: '527',
     modelName: 'Dyson Pure Hot+Cool',
-    modelCode: 'HP04',
-    series: 'hot-cool',
-    features: FEATURES_HOT_COOL_JET,
-    formaldehyde: false,
-  },
-  {
-    productType: '358K',
-    modelName: 'Dyson Pure Hot+Cool Cryptomic',
-    modelCode: 'HP06',
+    modelCode: 'HP04', // Also covers HP06 (Cryptomic) which shares the same product type
     series: 'hot-cool',
     features: FEATURES_HOT_COOL_JET,
     formaldehyde: false,
@@ -325,6 +317,14 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
     series: 'humidify-cool',
     features: FEATURES_HUMIDIFY_COOL_FORMALDEHYDE,
     formaldehyde: true,
+  },
+  {
+    productType: '358K',
+    modelName: 'Dyson Purifier Humidify+Cool De-Nox',
+    modelCode: 'PH05',
+    series: 'humidify-cool',
+    features: FEATURES_HUMIDIFY_COOL_FORMALDEHYDE,
+    formaldehyde: false,
   },
 
   // Big+Quiet Series


### PR DESCRIPTION
## Summary
- Add PH05 (Dyson Purifier Humidify+Cool PH2 De-Nox) with product type `358K`
- Fix HP06 (Cryptomic) incorrectly mapped to `358K` — it shares `527` with HP04
- Update README supported devices table

## Details
The PH05 uses MQTT product type `358K`, confirmed by the [matterbridge-dyson-robot](https://github.com/thoukydides/matterbridge-dyson-robot) project (v1.3.1 changelog) and retailer listings.

HP06 was incorrectly assigned product type `358K` (which belongs to the Humidify+Cool series). No open-source Dyson project lists HP06 with its own product type — it shares `527` with HP04, the same pattern as TP04/TP06 sharing `438`.

Closes #2

## Test plan
- [x] All existing tests pass (527 tests)
- [x] TypeScript build succeeds
- [ ] Verify PH05 device discovery with actual hardware