### PR TITLE
feat: add CF1 support (product type 739)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | **Purifier Humidify+Cool Formaldehyde** | PH04 | Fan, Humidifier, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Humidify+Cool De-Nox** | PH05 | Fan, Humidifier, Air Quality (incl. NO2), Temp, Humidity, Jet Focus |
 | **Purifier Big+Quiet** | BP02, BP03, BP04, BP06 | Fan, Air Quality (incl. NO2), Temp, Humidity |
+| **Cool** | CF1 | Fan, Oscillation |
 
 ## Installation
 

--- a/src/accessories/dysonLinkAccessory.ts
+++ b/src/accessories/dysonLinkAccessory.ts
@@ -159,6 +159,7 @@ export class DysonLinkAccessory extends DysonAccessory {
       api: this.api,
       log: this.log,
       deviceName,
+      supportsAutoMode: features.autoMode,
     });
 
     // Get the primary service for linking secondary services

--- a/src/accessories/services/fanService.ts
+++ b/src/accessories/services/fanService.ts
@@ -29,6 +29,12 @@ export interface FanServiceConfig {
   log: Logging;
   /** Device name to display in HomeKit */
   deviceName: string;
+  /**
+   * Whether the device supports auto mode. When false (e.g. plain fans with
+   * no air-quality sensor), the required TargetAirPurifierState characteristic
+   * is pinned to MANUAL so HomeKit does not offer a non-functional Auto toggle.
+   */
+  supportsAutoMode?: boolean;
 }
 
 /**
@@ -114,9 +120,15 @@ export class FanService {
 
     // Set up TargetAirPurifierState characteristic (required)
     // 0 = MANUAL, 1 = AUTO
-    this.service.getCharacteristic(Characteristic.TargetAirPurifierState)
+    const targetState = this.service.getCharacteristic(Characteristic.TargetAirPurifierState)
       .onGet(this.handleTargetStateGet.bind(this))
       .onSet(this.handleTargetStateSet.bind(this));
+    // Devices without auto mode (plain fans) can only ever be MANUAL. Restrict
+    // the allowed values so HomeKit hides the Auto option instead of showing a
+    // toggle that would send an unsupported command to the device.
+    if (config.supportsAutoMode === false) {
+      targetState.setProps({ validValues: [TargetAirPurifierState.MANUAL] });
+    }
 
     // Set up RotationSpeed characteristic (optional but we want it)
     this.service.getCharacteristic(Characteristic.RotationSpeed)

--- a/src/config/deviceCatalog.ts
+++ b/src/config/deviceCatalog.ts
@@ -17,7 +17,8 @@ export type DeviceSeries =
   | 'hot-cool-link'       // HP02 (older Link series)
   | 'hot-cool'            // HP04, HP06, HP07, HP09, HP11
   | 'humidify-cool'       // PH01, PH02, PH03, PH04, PH05
-  | 'big-quiet';          // BP02, BP03, BP04, BP06
+  | 'big-quiet'           // BP02, BP03, BP04, BP06
+  | 'cool';               // CF1 (plain fan, no sensors)
 
 /**
  * Device model definition
@@ -155,6 +156,19 @@ const FEATURES_BIG_QUIET: DeviceFeatures = {
   oscillation: false,
   frontAirflow: false,
   no2Sensor: true,
+};
+
+/**
+ * Cool series (plain fan: oscillation + speed only, no sensors/filters).
+ * Uses the modern (non-Link) protocol path: fmod/fnsp/oson.
+ */
+const FEATURES_COOL_FAN: DeviceFeatures = {
+  ...DEFAULT_FEATURES,
+  fan: true,
+  oscillation: true,
+  autoMode: false,
+  nightMode: false,
+  continuousMonitoring: false,
 };
 
 // ============================================================================
@@ -358,6 +372,16 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
     modelCode: 'BP06',
     series: 'big-quiet',
     features: FEATURES_BIG_QUIET,
+    formaldehyde: false,
+  },
+
+  // Cool Series (plain fan, no sensors)
+  {
+    productType: '739',
+    modelName: 'Dyson Cool',
+    modelCode: 'CF1',
+    series: 'cool',
+    features: FEATURES_COOL_FAN,
     formaldehyde: false,
   },
 ] as const;


### PR DESCRIPTION
Adds the **Dyson Cool CF1** (product type `739`) to the device catalog as a fan-only accessory (oscillation + speed; no sensors, filters, heating, or auto mode).

Closes #7

## Evidence
Confirmed against the MyDyson Android APK:
- `739Config.json`: `739` uses standard **MQTT 3.1** with the usual topics and the `_dyson_mqtt._tcp.` mDNS service — identical to every device the plugin already discovers.
- `MachineType.java`: `739` is **not** a gen1 machine (gen1 = 475/469/455/N223), so it uses the modern protocol path (`fmod`/`fnsp`/`oson`) the plugin already drives for the 438/527/664 families.
- It is grouped with the non-purifier **fan family** and excluded from all air-quality/sensor groups, matching the reporter's "plain fan, no sensors" description.

## Changes
- New `'cool'` device series + `FEATURES_COOL_FAN` template and the `739` catalog entry.
- Pin the required `TargetAirPurifierState` characteristic to `MANUAL` when a device lacks auto mode, so HomeKit no longer surfaces a non-functional Auto toggle on sensorless fans (`FanService` now takes `supportsAutoMode`).
- README supported-devices row.

## Testing
- `tsc --noEmit` clean, `eslint` clean, full suite **592/592** pass.
- ⚠️ Protocol fields are inferred from the APK, not verified against real hardware. Needs the reporter (@mnvwmt) to test a build and confirm power/speed/oscillation behave.
