### PR TITLE
fix(protocol): CF1 (739) power on/off uses fpwr, not fmod

### DIFF
--- a/src/config/deviceCatalog.ts
+++ b/src/config/deviceCatalog.ts
@@ -21,6 +21,19 @@ export type DeviceSeries =
   | 'cool';               // CF1 (plain fan, no sensors)
 
 /**
+ * MQTT protocol used for the fan power (on/off) command.
+ *
+ * - `fmod`: legacy field carrying power *and* mode (`OFF`/`FAN`/`AUTO`).
+ *   Accepted by most purifier models.
+ * - `fpwr`: dedicated power field (`ON`/`OFF`), with `auto`/`fnsp` carrying
+ *   mode/speed separately. Used by the Pure Cool Link series and by newer
+ *   fans (e.g. CF1) that do NOT honour `fmod` for power.
+ *
+ * Defaults to `fmod` when unspecified — see {@link getPowerProtocol}.
+ */
+export type PowerProtocol = 'fmod' | 'fpwr';
+
+/**
  * Device model definition
  */
 export interface DeviceModel {
@@ -36,6 +49,11 @@ export interface DeviceModel {
   features: DeviceFeatures;
   /** Whether this is a formaldehyde-detecting model */
   formaldehyde: boolean;
+  /**
+   * Fan power command protocol. Defaults to `fmod` when omitted.
+   * Set to `fpwr` for devices that only respond to the dedicated power field.
+   */
+  powerProtocol?: PowerProtocol;
 }
 
 // ============================================================================
@@ -187,6 +205,7 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
     series: 'pure-cool-link',
     features: FEATURES_PURE_COOL_LINK,
     formaldehyde: false,
+    powerProtocol: 'fpwr',
   },
   {
     productType: '469',
@@ -195,6 +214,7 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
     series: 'pure-cool-link',
     features: FEATURES_PURE_COOL_LINK,
     formaldehyde: false,
+    powerProtocol: 'fpwr',
   },
 
   // Pure Cool Series
@@ -383,6 +403,8 @@ export const DEVICE_CATALOG: readonly DeviceModel[] = [
     series: 'cool',
     features: FEATURES_COOL_FAN,
     formaldehyde: false,
+    // CF1 ignores `fmod` for power; it only responds to the dedicated `fpwr` field.
+    powerProtocol: 'fpwr',
   },
 ] as const;
 
@@ -432,6 +454,17 @@ export function getSupportedProductTypes(): string[] {
  */
 export function getDeviceFeatures(productType: string): DeviceFeatures {
   return productTypeMap.get(productType)?.features ?? DEFAULT_FEATURES;
+}
+
+/**
+ * Get the fan power command protocol by product type.
+ *
+ * @param productType - Dyson product type code
+ * @returns `'fpwr'` for devices that require the dedicated power field,
+ *          otherwise `'fmod'` (the default for unspecified / unknown types)
+ */
+export function getPowerProtocol(productType: string): PowerProtocol {
+  return productTypeMap.get(productType)?.powerProtocol ?? 'fmod';
 }
 
 /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,11 +17,13 @@ export {
 export {
   type DeviceSeries,
   type DeviceModel,
+  type PowerProtocol,
   DEVICE_CATALOG,
   getDeviceByProductType,
   isProductTypeSupported,
   getSupportedProductTypes,
   getDeviceFeatures,
+  getPowerProtocol,
   getDeviceModelName,
   getProductTypeDisplayNames,
   getDevicesBySeries,

--- a/src/devices/dysonLinkDevice.ts
+++ b/src/devices/dysonLinkDevice.ts
@@ -10,7 +10,7 @@ import type { DeviceFeatures, DeviceInfo } from './types.js';
 import { MessageCodec, FAN_SPEED, HEATING_TEMP, HUMIDITY, PROTOCOL, FORMAT, TEMPERATURE } from '../protocol/messageCodec.js';
 import type { MqttClientFactory } from './dysonDevice.js';
 import type { MqttConnectFn } from '../protocol/mqttClient.js';
-import { getDeviceFeatures } from '../config/index.js';
+import { getDeviceFeatures, getPowerProtocol } from '../config/index.js';
 
 // ============================================================================
 // DysonLinkDevice
@@ -33,8 +33,11 @@ export class DysonLinkDevice extends DysonDevice {
   /** Features supported by this device */
   readonly supportedFeatures: DeviceFeatures;
 
-  /** Whether this is a Link series device (uses different protocol) */
-  private readonly isLinkSeries: boolean;
+  /**
+   * Whether this device uses the dedicated `fpwr` power field instead of the
+   * legacy `fmod` field. Derived from the device catalog (see PowerProtocol).
+   */
+  private readonly usesFpwrProtocol: boolean;
 
   /** Pending command fields to be batched and sent */
   private pendingCommandFields: Record<string, string> = {};
@@ -61,10 +64,11 @@ export class DysonLinkDevice extends DysonDevice {
     this.productType = deviceInfo.productType;
     this.supportedFeatures = getDeviceFeatures(deviceInfo.productType);
 
-    // Check if this is a Pure Cool Link device (TP02, DP01) - uses fpwr/auto protocol
-    // Note: HP02 (455) is called "Hot+Cool Link" but uses fmod like newer devices
-    // Only TP02 (475) and DP01 (469) use the older fpwr/auto protocol
-    this.isLinkSeries = deviceInfo.productType === '475' || deviceInfo.productType === '469';
+    // Power command protocol is catalog-driven. Most models use the legacy
+    // `fmod` field (power + mode combined); a subset — the Pure Cool Link
+    // series (TP02/DP01) and newer fans like the CF1 (739) — only honour the
+    // dedicated `fpwr` field for power, with `auto`/`fnsp` for mode/speed.
+    this.usesFpwrProtocol = getPowerProtocol(deviceInfo.productType) === 'fpwr';
   }
 
   /**
@@ -105,7 +109,9 @@ export class DysonLinkDevice extends DysonDevice {
   /**
    * Set fan power on or off
    *
-   * Uses fmod command for newer models, fpwr/auto/fnsp for Link series.
+   * Uses the dedicated `fpwr` field (with `auto`/`fnsp`) for devices whose
+   * catalog entry declares `powerProtocol: 'fpwr'`, otherwise the legacy
+   * `fmod` field. See {@link getPowerProtocol}.
    *
    * @param on - True to turn on, false to turn off
    */
@@ -118,7 +124,7 @@ export class DysonLinkDevice extends DysonDevice {
         return;
       }
 
-      if (this.isLinkSeries) {
+      if (this.usesFpwrProtocol) {
         if (this.state.autoMode) {
           this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
         } else {
@@ -141,7 +147,7 @@ export class DysonLinkDevice extends DysonDevice {
       this.turningOff = true;
       this.pendingCommandFields = {};
       try {
-        if (this.isLinkSeries) {
+        if (this.usesFpwrProtocol) {
           await this.sendCommand({ fpwr: PROTOCOL.OFF });
         } else {
           await this.sendCommand({ fmod: PROTOCOL.OFF });
@@ -161,7 +167,7 @@ export class DysonLinkDevice extends DysonDevice {
     if (this.turningOff) {
       return;
     }
-    if (this.isLinkSeries) {
+    if (this.usesFpwrProtocol) {
       if (speed < 0) {
         this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
       } else {
@@ -208,7 +214,7 @@ export class DysonLinkDevice extends DysonDevice {
     if (this.turningOff) {
       return;
     }
-    if (this.isLinkSeries) {
+    if (this.usesFpwrProtocol) {
       if (on) {
         this.queueCommand({ fpwr: PROTOCOL.ON, auto: PROTOCOL.ON, fnsp: PROTOCOL.AUTO });
       } else {

--- a/test/unit/devices/dysonLinkDevice.test.ts
+++ b/test/unit/devices/dysonLinkDevice.test.ts
@@ -138,6 +138,40 @@ describe('DysonLinkDevice', () => {
     });
   });
 
+  describe('setFanPower for CF1 (739, fpwr protocol)', () => {
+    let cf1Device: DysonLinkDevice;
+    let cf1MqttClient: ReturnType<typeof createMockMqttClient>;
+
+    beforeEach(async () => {
+      cf1MqttClient = createMockMqttClient();
+      cf1Device = new DysonLinkDevice(
+        { ...defaultDeviceInfo, productType: '739' },
+        vi.fn().mockReturnValue(cf1MqttClient),
+      );
+      await cf1Device.connect();
+    });
+
+    it('should send fpwr ON (not fmod) when turning on', async () => {
+      await cf1Device.setFanPower(true);
+      await flushMicrotasks();
+
+      const command = cf1MqttClient.publishCommand.mock.calls[0][0];
+      expect(command.data).toMatchObject({ fpwr: 'ON' });
+      expect(command.data).not.toHaveProperty('fmod');
+    });
+
+    it('should send fpwr OFF (not fmod) when turning off', async () => {
+      await cf1Device.setFanPower(false);
+      await flushMicrotasks();
+
+      expect(cf1MqttClient.publishCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { fpwr: 'OFF' },
+        }),
+      );
+    });
+  });
+
   describe('setFanSpeed', () => {
     beforeEach(async () => {
       await device.connect();


### PR DESCRIPTION
## Summary

Fixes the CF1 power toggle reported in #7 (last comment): oscillation and speed work, but the main on/off does nothing and reverts.

**Root cause:** the CF1 (product type `739`) only honours the dedicated `fpwr` power field and ignores the legacy `fmod` field. Because `739` wasn't in the hardcoded fpwr list, `setFanPower` sent `fmod: FAN`/`fmod: OFF`, which the fan silently dropped. Speed (`fnsp`) and oscillation (`oson`) go through their own fields, so they kept working — exactly matching the report.

Confirmed against the decompiled MyDyson app: the gen1/`fmod` group is exactly `{455, 455C, 475, 469}`; every newer machine, including `739`, uses `fpwr`.

## Change

Make the power protocol **catalog-driven** instead of a hardcoded 2-model check:

- Add optional `powerProtocol: 'fmod' | 'fpwr'` to `DeviceModel` + a `getPowerProtocol()` helper (defaults to `fmod`).
- Mark `739` as `fpwr` (the fix), and pin the Pure Cool Link models `475`/`469` to `fpwr` to preserve their current behaviour.
- Every other model keeps `fmod` — **no behaviour change** for existing devices.

## Tests

- Added CF1 tests asserting power sends `fpwr` (not `fmod`) on/off.
- Full suite green: **594 passed**. `tsc` build clean.

## Follow-up

The decompiled app indicates all gen2 devices officially use `fpwr`, yet the plugin has shipped `fmod` for them and it works — so most gen2 firmware accepts both. Whether to migrate all gen2 devices to `fpwr` needs real TP04/HP04 testing; tracking separately rather than changing working devices here.