### PR TITLE
Enable cf1 night mode

### DIFF
--- a/src/config/deviceCatalog.ts
+++ b/src/config/deviceCatalog.ts
@@ -185,7 +185,7 @@ const FEATURES_COOL_FAN: DeviceFeatures = {
   fan: true,
   oscillation: true,
   autoMode: false,
-  nightMode: false,
+  nightMode: true,
   continuousMonitoring: false,
 };
 

--- a/test/unit/config/deviceCatalog.test.ts
+++ b/test/unit/config/deviceCatalog.test.ts
@@ -115,6 +115,12 @@ describe('Device Catalog', () => {
       expect(features.frontAirflow).toBe(false);
     });
 
+    it('should support night mode for CF1', () => {
+      const features = getDeviceFeatures('739');
+      expect(features.fan).toBe(true);
+      expect(features.nightMode).toBe(true);
+    });
+
     it('should return DEFAULT_FEATURES for unknown product type', () => {
       const features = getDeviceFeatures('999');
       expect(features).toEqual(DEFAULT_FEATURES);


### PR DESCRIPTION
## Summary

Enable the existing Night Mode service for the Dyson Cool CF1 (product type `739`).

The plugin already:

- Sends Night Mode commands using `nmod: "ON"` and `nmod: "OFF"`.
- Decodes `nmod` from device state responses.
- Creates the HomeKit Night Mode switch for devices whose catalog entry declares `nightMode: true`.

The CF1 catalog currently declares `nightMode: false`, preventing the switch from appearing even when `enableNightMode` is enabled in Homebridge.

## Device information

- Model: Dyson Cool CF1
- Product type: `739`
- Feature: Sleep Mode / quiet operation with dimmed display

## Testing

Tested on a CF1. Sending `nmod: "ON"` activates Sleep/Quiet Mode, and `nmod: "OFF"` disables it. The HomeKit switch reflects the returned `nmod` device state.

## Changes

- Mark Night Mode as supported in `FEATURES_COOL_FAN`.
- Add a catalog regression test for product type `739`.