### PR TITLE
feat(config): implement the enable*WhenActivating options

### DIFF
--- a/src/accessories/dysonLinkAccessory.ts
+++ b/src/accessories/dysonLinkAccessory.ts
@@ -64,6 +64,14 @@ export interface DeviceOptions {
   /** Enable full humidity range (0-100%) for humidifier */
   fullRangeHumidity?: boolean;
 
+  // Activation behaviour
+  /** Enable auto mode automatically when the device is turned on */
+  enableAutoModeWhenActivating?: boolean;
+  /** Enable oscillation automatically when the device is turned on */
+  enableOscillationWhenActivating?: boolean;
+  /** Enable night mode automatically when the device is turned on */
+  enableNightModeWhenActivating?: boolean;
+
   // Service toggles
   /** Enable night mode switch */
   isNightModeEnabled?: boolean;
@@ -151,6 +159,15 @@ export class DysonLinkAccessory extends DysonAccessory {
     // they're available even though setupServices() is called during construction
     const opts: DeviceOptions = (this.accessory.context._deviceOptions as DeviceOptions) ?? this.options ?? {};
     const deviceName = this.accessory.displayName;
+
+    // Modes to switch on automatically whenever the device is activated.
+    // The device layer applies these on off -> on transitions only, and gates
+    // each one on the model's catalog features.
+    linkDevice.setActivationDefaults({
+      autoMode: opts.enableAutoModeWhenActivating,
+      oscillation: opts.enableOscillationWhenActivating,
+      nightMode: opts.enableNightModeWhenActivating,
+    });
 
     // Create FanService for fan control (all devices) - this is the primary service
     this.fanService = new FanService({

--- a/src/config/deviceCatalog.ts
+++ b/src/config/deviceCatalog.ts
@@ -177,8 +177,10 @@ const FEATURES_BIG_QUIET: DeviceFeatures = {
 };
 
 /**
- * Cool series (plain fan: oscillation + speed only, no sensors/filters).
- * Uses the modern (non-Link) protocol path: fmod/fnsp/oson.
+ * Cool series (plain fan: no air-quality sensors, no filters).
+ *
+ * Currently CF1 only, which takes power via the dedicated `fpwr` field rather
+ * than `fmod` — see the `powerProtocol` on its catalog entry.
  */
 const FEATURES_COOL_FAN: DeviceFeatures = {
   ...DEFAULT_FEATURES,

--- a/src/devices/dysonLinkDevice.ts
+++ b/src/devices/dysonLinkDevice.ts
@@ -17,6 +17,22 @@ import { getDeviceFeatures, getPowerProtocol } from '../config/index.js';
 // ============================================================================
 
 /**
+ * Modes to switch on automatically whenever the device is activated.
+ *
+ * Each flag mirrors an `enable*WhenActivating` option in the plugin config.
+ * Flags are additionally gated by the device's catalog features, so a mode is
+ * never sent to a model that does not support it.
+ */
+export interface ActivationDefaults {
+  /** Enable auto mode when the device is turned on */
+  autoMode?: boolean;
+  /** Enable oscillation when the device is turned on */
+  oscillation?: boolean;
+  /** Enable night mode when the device is turned on */
+  nightMode?: boolean;
+}
+
+/**
  * Dyson Link Device implementation
  *
  * Handles fan control for all Dyson purifier devices.
@@ -47,6 +63,9 @@ export class DysonLinkDevice extends DysonDevice {
 
   /** Whether a power-off is in progress (prevents concurrent commands from overriding OFF) */
   private turningOff = false;
+
+  /** Modes to switch on automatically on the next off -> on transition */
+  private activationDefaults: ActivationDefaults = {};
 
   /**
    * Create a new DysonLinkDevice
@@ -139,6 +158,8 @@ export class DysonLinkDevice extends DysonDevice {
           this.queueCommand({ fmod: PROTOCOL.FAN });
         }
       }
+
+      await this.applyActivationDefaults();
     } else {
       // Power off: send directly to prevent concurrent mode changes
       // (e.g. TargetAirPurifierState) from overwriting the OFF command
@@ -156,6 +177,47 @@ export class DysonLinkDevice extends DysonDevice {
         this.turningOff = false;
       }
     }
+  }
+
+  /**
+   * Configure modes to switch on automatically whenever the device is activated.
+   *
+   * Applied only on an off -> on transition, and only for modes the device
+   * supports. Passing an empty object clears any previously set defaults.
+   *
+   * @param defaults - Modes to enable on activation
+   */
+  setActivationDefaults(defaults: ActivationDefaults): void {
+    this.activationDefaults = defaults;
+  }
+
+  /**
+   * Queue the configured activation modes alongside a power-on command.
+   *
+   * These are queued from the same tick as the power command, so they merge
+   * into a single MQTT message instead of racing it. Modes the device does not
+   * support are skipped rather than sent and ignored by the device.
+   */
+  private async applyActivationDefaults(): Promise<void> {
+    const { autoMode, oscillation, nightMode } = this.activationDefaults;
+    const queued: Promise<void>[] = [];
+
+    // Collected rather than awaited one by one: each `await` would yield to the
+    // microtask queue and let the pending flush run, splitting what should be a
+    // single MQTT message into one per mode.
+    if (autoMode && this.supportedFeatures.autoMode) {
+      queued.push(this.setAutoMode(true));
+    }
+
+    if (oscillation && this.supportedFeatures.oscillation) {
+      queued.push(this.setOscillation(true));
+    }
+
+    if (nightMode && this.supportedFeatures.nightMode) {
+      queued.push(this.setNightMode(true));
+    }
+
+    await Promise.all(queued);
   }
 
   /**

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -52,6 +52,12 @@ interface DeviceConfig {
   heatingServiceType?: 'thermostat' | 'heater-cooler' | 'both';
   /** Enable full humidity range (0-100%) */
   fullRangeHumidity?: boolean;
+  /** Enable auto mode automatically when the device is turned on */
+  enableAutoModeWhenActivating?: boolean;
+  /** Enable oscillation automatically when the device is turned on */
+  enableOscillationWhenActivating?: boolean;
+  /** Enable night mode automatically when the device is turned on */
+  enableNightModeWhenActivating?: boolean;
   /** Enable night mode switch */
   isNightModeEnabled?: boolean;
   /** Enable jet focus switch */
@@ -333,6 +339,9 @@ export class DysonPlatformAccessory {
       isHeatingDisabled: config.isHeatingDisabled,
       heatingServiceType: config.heatingServiceType,
       fullRangeHumidity: config.fullRangeHumidity,
+      enableAutoModeWhenActivating: config.enableAutoModeWhenActivating,
+      enableOscillationWhenActivating: config.enableOscillationWhenActivating,
+      enableNightModeWhenActivating: config.enableNightModeWhenActivating,
       isNightModeEnabled: config.isNightModeEnabled,
       isJetFocusEnabled: config.isJetFocusEnabled,
       isContinuousMonitoringEnabled: config.isContinuousMonitoringEnabled,

--- a/test/unit/accessories/dysonLinkAccessory.test.ts
+++ b/test/unit/accessories/dysonLinkAccessory.test.ts
@@ -468,6 +468,27 @@ describe('DysonLinkAccessory', () => {
       expect(accessory.getNightModeService()).toBeUndefined();
     });
 
+    it('should pass activation defaults to the device', () => {
+      const setActivationDefaults = vi.spyOn(device, 'setActivationDefaults');
+
+      accessory = new DysonLinkAccessory({
+        accessory: mockAccessory,
+        device,
+        api: mockApi as unknown as API,
+        log: mockLog,
+        options: {
+          enableAutoModeWhenActivating: true,
+          enableNightModeWhenActivating: true,
+        },
+      });
+
+      expect(setActivationDefaults).toHaveBeenCalledWith({
+        autoMode: true,
+        oscillation: undefined,
+        nightMode: true,
+      });
+    });
+
     it('should enable continuous monitoring when isContinuousMonitoringEnabled is true', () => {
       accessory = new DysonLinkAccessory({
         accessory: mockAccessory,

--- a/test/unit/devices/dysonLinkDevice.test.ts
+++ b/test/unit/devices/dysonLinkDevice.test.ts
@@ -172,6 +172,113 @@ describe('DysonLinkDevice', () => {
     });
   });
 
+  describe('activation defaults', () => {
+    beforeEach(async () => {
+      await device.connect();
+    });
+
+    it('should not send extra fields when no defaults are configured', async () => {
+      await device.setFanPower(true);
+      await flushMicrotasks();
+
+      expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { fmod: 'FAN' },
+        }),
+      );
+    });
+
+    it('should enable configured modes in the same command as power on', async () => {
+      device.setActivationDefaults({ autoMode: true, oscillation: true, nightMode: true });
+
+      await device.setFanPower(true);
+      await flushMicrotasks();
+
+      // All queued in one tick, so they merge into a single MQTT message.
+      // Auto mode wins over the FAN value queued by setFanPower.
+      expect(mockMqttClient.publishCommand).toHaveBeenCalledTimes(1);
+      expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { fmod: 'AUTO', oson: 'ON', nmod: 'ON' },
+        }),
+      );
+    });
+
+    it('should apply only the modes that are enabled', async () => {
+      device.setActivationDefaults({ oscillation: true });
+
+      await device.setFanPower(true);
+      await flushMicrotasks();
+
+      const command = mockMqttClient.publishCommand.mock.calls[0][0];
+      expect(command.data).toMatchObject({ oson: 'ON' });
+      expect(command.data).not.toHaveProperty('nmod');
+    });
+
+    it('should skip modes the device does not support', async () => {
+      const cf1MqttClient = createMockMqttClient();
+      const cf1Device = new DysonLinkDevice(
+        { ...defaultDeviceInfo, productType: '739' },
+        vi.fn().mockReturnValue(cf1MqttClient),
+      );
+      await cf1Device.connect();
+
+      // CF1 is a plain fan with no auto mode; oscillation is supported.
+      cf1Device.setActivationDefaults({ autoMode: true, oscillation: true });
+
+      await cf1Device.setFanPower(true);
+      await flushMicrotasks();
+
+      const command = cf1MqttClient.publishCommand.mock.calls[0][0];
+      expect(command.data).toMatchObject({ fpwr: 'ON', oson: 'ON' });
+      expect(command.data).toMatchObject({ auto: 'OFF' });
+    });
+
+    it('should not re-apply defaults when the device is already on', async () => {
+      device.setActivationDefaults({ nightMode: true });
+
+      // Device reports itself as already running
+      const message: MqttMessage = {
+        topic: '438/ABC-AB-12345678/status/current',
+        payload: Buffer.from('{}'),
+        data: {
+          msg: 'CURRENT-STATE',
+          'product-state': { fmod: 'FAN', fnsp: '0005', nmod: 'OFF' },
+        },
+      };
+      mockMqttClient._emit('message', message);
+
+      await device.setFanPower(true);
+      await flushMicrotasks();
+
+      expect(mockMqttClient.publishCommand).not.toHaveBeenCalled();
+    });
+
+    it('should not apply defaults when powering off', async () => {
+      device.setActivationDefaults({ nightMode: true, oscillation: true });
+
+      await device.setFanPower(false);
+      await flushMicrotasks();
+
+      expect(mockMqttClient.publishCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { fmod: 'OFF' },
+        }),
+      );
+    });
+
+    it('should clear previously configured defaults', async () => {
+      device.setActivationDefaults({ nightMode: true });
+      device.setActivationDefaults({});
+
+      await device.setFanPower(true);
+      await flushMicrotasks();
+
+      const command = mockMqttClient.publishCommand.mock.calls[0][0];
+      expect(command.data).not.toHaveProperty('nmod');
+    });
+  });
+
   describe('setFanSpeed', () => {
     beforeEach(async () => {
       await device.connect();


### PR DESCRIPTION
## Summary

The three per-device options `enableAutoModeWhenActivating`, `enableOscillationWhenActivating` and `enableNightModeWhenActivating` are declared in `config.schema.json` and rendered by the Homebridge UI, but had no implementation anywhere in `src/` — users could set them and nothing happened. Their schema sibling `fullRangeHumidity` *is* wired up, so this looks like an oversight rather than intent.

## Approach

Activation defaults are applied in the device layer, where `setFanPower()` already detects the off → on transition (it early-returns when the device is already on). One hook there covers every power-on path:

- the `Active` characteristic
- the speed slider powering the fan on implicitly
- heater activation

Config flows `config.schema.json` → `DeviceConfig` → `extractDeviceOptions` → `DeviceOptions` → `setActivationDefaults()`, matching how `fullRangeHumidity` is already threaded through.

Two details worth noting:

- **Feature gating** — each mode is checked against the model's catalog features, so auto mode is never sent to a plain fan (CF1) nor oscillation to a BP02. The gating lives in the device, which already owns `supportedFeatures`.
- **Single MQTT message** — the mode commands are queued in the same tick as the power command, so the existing microtask batching merges them. A TP04 activating with all three enabled emits one `{fmod: 'AUTO', oson: 'ON', nmod: 'ON'}` rather than three messages. Awaiting the setters one by one would yield to the microtask queue and let the pending flush fire between each, so they are collected and awaited together.

No changes to `mergeDeviceConfig` — these three are per-device only in the schema, with no global counterpart.

## Also

Drops a stale feature enumeration from the `FEATURES_COOL_FAN` comment, which additionally claimed the preset uses `fmod` when the CF1 entry sets `powerProtocol: 'fpwr'`.

## Testing

7 new tests: merged-command behaviour, per-mode selection, feature-gate skipping, no re-application when already on, no application on power-off, clearing defaults, and the accessory → device option mapping. Full suite passes (603).